### PR TITLE
Issue 41: Filter out empty builder metadata

### DIFF
--- a/reflective-fluent-builders-generator/src/main/java/com/github/tobi/laa/reflective/fluent/builders/service/api/BuilderMetadataService.java
+++ b/reflective-fluent-builders-generator/src/main/java/com/github/tobi/laa/reflective/fluent/builders/service/api/BuilderMetadataService.java
@@ -2,6 +2,7 @@ package com.github.tobi.laa.reflective.fluent.builders.service.api;
 
 import com.github.tobi.laa.reflective.fluent.builders.model.BuilderMetadata;
 
+import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -47,4 +48,17 @@ public interface BuilderMetadataService {
      * {@code null}.
      */
     Set<Class<?>> filterOutNonBuildableClasses(final Set<Class<?>> classes);
+
+    /**
+     * <p>
+     * Filters out all metadata for builders whose generation would yield an empty builder, i.e. those for which no
+     * setters have been detected at all.
+     * </p>
+     *
+     * @param builderMetadata The builder metadata from which to filter out all metadata for builders whose generation
+     *                        would yield an empty builder. Must not be {@code null}.
+     * @return {@code builderMetadata} but without all metadata for builders whose generation would yield an empty
+     * builder. Never {@code null}.
+     */
+    Set<BuilderMetadata> filterOutEmptyBuilders(final Collection<BuilderMetadata> builderMetadata);
 }

--- a/reflective-fluent-builders-generator/src/main/java/com/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/com/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
@@ -133,4 +133,12 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
     private boolean placeBuildersInSamePackage(final Class<?> clazz) {
         return PACKAGE_PLACEHOLDER.equals(properties.getBuilderPackage()) || properties.getBuilderPackage().equals(clazz.getPackageName());
     }
+
+    @Override
+    public Set<BuilderMetadata> filterOutEmptyBuilders(final Collection<BuilderMetadata> builderMetadata) {
+        Objects.requireNonNull(builderMetadata);
+        return builderMetadata.stream() //
+                .filter(metadata -> !metadata.getBuiltType().getSetters().isEmpty()) //
+                .collect(Collectors.toSet());
+    }
 }

--- a/reflective-fluent-builders-generator/src/test/java/com/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/com/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImplTest.java
@@ -27,6 +27,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.SortedSet;
@@ -193,5 +194,79 @@ class BuilderMetadataServiceImplTest {
                         Visibility.PACKAGE_PRIVATE, //
                         Set.of(SimpleClass.class),
                         Collections.emptySet()));
+    }
+
+    @Test
+    void testFilterOutEmptyBuildersNull() {
+        // Arrange
+        final Collection<BuilderMetadata> builderMetadata = null;
+        // Act
+        final Executable filterOutEmptyBuilders = () -> builderService.filterOutEmptyBuilders(builderMetadata);
+        // Assert
+        assertThrows(NullPointerException.class, filterOutEmptyBuilders);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testFilterOutEmptyBuilders(final Collection<BuilderMetadata> builderMetadata, final Set<BuilderMetadata> expected) {
+        // Act
+        final Set<BuilderMetadata> actual = builderService.filterOutEmptyBuilders(builderMetadata);
+        // Assert
+        assertEquals(expected, actual);
+    }
+
+    private static Stream<Arguments> testFilterOutEmptyBuilders() {
+        return Stream.of( //
+                Arguments.of(Collections.emptySet(), Collections.emptySet()), //
+                Arguments.of(
+                        Collections.singleton( //
+                                BuilderMetadata.builder() //
+                                        .packageName("com.github.tobi.laa.reflective.fluent.builders.test.models.simple") //
+                                        .name("SimpleClassBuilder") //
+                                        .builtType(BuilderMetadata.BuiltType.builder() //
+                                                .type(SimpleClass.class) //
+                                                .accessibleNonArgsConstructor(true) //
+                                                .build()) //
+                                        .build()),
+                        Collections.emptySet()),
+                Arguments.of(
+                        Set.of( //
+                                BuilderMetadata.builder() //
+                                        .packageName("com.github.tobi.laa.reflective.fluent.builders.test.models.simple") //
+                                        .name("SimpleClassBuilder") //
+                                        .builtType(BuilderMetadata.BuiltType.builder() //
+                                                .type(SimpleClass.class) //
+                                                .accessibleNonArgsConstructor(true) //
+                                                .build()) //
+                                        .build(),
+                                BuilderMetadata.builder() //
+                                        .packageName("com.github.tobi.laa.reflective.fluent.builders.test.models.simple") //
+                                        .name("SimpleClassBuilder") //
+                                        .builtType(BuilderMetadata.BuiltType.builder() //
+                                                .type(SimpleClass.class) //
+                                                .accessibleNonArgsConstructor(true) //
+                                                .setter(SimpleSetter.builder() //
+                                                        .methodName("setPub") //
+                                                        .paramName("pub") //
+                                                        .paramType(int.class) //
+                                                        .visibility(Visibility.PUBLIC) //
+                                                        .build())
+                                                .build()) //
+                                        .build()),
+                        Collections.singleton( //
+                                BuilderMetadata.builder() //
+                                        .packageName("com.github.tobi.laa.reflective.fluent.builders.test.models.simple") //
+                                        .name("SimpleClassBuilder") //
+                                        .builtType(BuilderMetadata.BuiltType.builder() //
+                                                .type(SimpleClass.class) //
+                                                .accessibleNonArgsConstructor(true) //
+                                                .setter(SimpleSetter.builder() //
+                                                        .methodName("setPub") //
+                                                        .paramName("pub") //
+                                                        .paramType(int.class) //
+                                                        .visibility(Visibility.PUBLIC) //
+                                                        .build())
+                                                .build()) //
+                                        .build())));
     }
 }

--- a/reflective-fluent-builders-maven-plugin/src/main/java/com/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/com/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Mojo(name = "generate-builders", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 @RequiredArgsConstructor(onConstructor = @__(@Inject))
@@ -75,6 +76,10 @@ public class GenerateBuildersMojo extends AbstractMojo {
         } catch (final IOException e) {
             throw new MojoFailureException("Could not create target directory " + target + '.', e);
         }
+        final var allMetadata = buildableClasses.stream() //
+                .map(builderMetadataService::collectBuilderMetadata) //
+                .collect(Collectors.toSet());
+        final var noneEmptyMetadata = builderMetadataService.filterOutEmptyBuilders(allMetadata);
         for (final var clazz : buildableClasses) {
             getLog().info("Generate builder for class " + clazz.getName() + '.');
             final var metadata = builderMetadataService.collectBuilderMetadata(clazz);


### PR DESCRIPTION
Fixes #41 

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Further documentation has been added to `README.md` where applicable.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [X] Build pipeline passes.
