### PR TITLE
#66 Fix compareTo for equivalent CollectionSetter/CollectionGetAndAdder

### DIFF
--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/AbstractSetter.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/AbstractSetter.java
@@ -5,7 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Objects;
-import java.util.function.Supplier;
+import java.util.function.IntSupplier;
 import java.util.stream.Stream;
 
 import static java.util.Comparator.naturalOrder;
@@ -37,10 +37,11 @@ public abstract class AbstractSetter implements Setter {
         if (equals(other)) {
             return 0;
         } else {
-            return Stream.<Supplier<Integer>>of( //
+            return Stream.<IntSupplier>of( //
                             () -> compare(paramName, other.getParamName(), naturalOrder()), //
-                            () -> compare(getParamType().getTypeName(), other.getParamType().getTypeName(), naturalOrder()))
-                    .map(Supplier::get) //
+                            () -> compare(getParamType().getTypeName(), other.getParamType().getTypeName(), naturalOrder()), //
+                            () -> compare(getClass().getName(), other.getClass().getName(), naturalOrder()))
+                    .map(IntSupplier::getAsInt) //
                     .filter(i -> i != 0) //
                     .findFirst() //
                     .orElse(1);

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/model/CollectionGetAndAdderTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/model/CollectionGetAndAdderTest.java
@@ -1,5 +1,6 @@
 package io.github.tobi.laa.reflective.fluent.builders.model;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -30,5 +31,29 @@ class CollectionGetAndAdderTest {
                 .visibility(Visibility.PRIVATE)
                 .paramTypeArg(Object.class)
                 .build());
+    }
+
+    @Test
+    void testCompareToEquivalentCollectionSetter() {
+        // Arrange
+        final var collectionGetAndAdder = CollectionGetAndAdder.builder()
+                .methodName("getSth")
+                .paramType(List.class)
+                .paramName("aName")
+                .visibility(Visibility.PRIVATE)
+                .paramTypeArg(Object.class)
+                .build();
+        final var collectionSetter = CollectionSetter.builder()
+                .methodName("setSth")
+                .paramType(List.class)
+                .paramName("aName")
+                .visibility(Visibility.PRIVATE)
+                .paramTypeArg(Object.class)
+                .build();
+        // Act
+        final var compareToSetter = collectionGetAndAdder.compareTo(collectionSetter);
+        final var compareFromSetter = collectionSetter.compareTo(collectionGetAndAdder);
+        // Assert
+        assertThat(compareToSetter).isNotZero().isEqualTo(compareFromSetter * -1);
     }
 }


### PR DESCRIPTION
Fixes #66

---

- [x] All commit messages contain meaningful descriptions.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [ ] Build pipeline passes.
