### PR TITLE
#107 Fix handling of package-private and protected constructors

### DIFF
--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
@@ -69,7 +69,7 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
 
     private boolean hasAccessibleNonArgsConstructor(final Class<?> clazz, final String builderPackage) {
         return Arrays //
-                .stream(clazz.getConstructors()) //
+                .stream(clazz.getDeclaredConstructors()) //
                 .filter(constructor -> isAccessible(constructor, builderPackage)) //
                 .mapToInt(Constructor::getParameterCount) //
                 .anyMatch(count -> count == 0);

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImplTest.java
@@ -144,7 +144,7 @@ class BuilderMetadataServiceImplTest {
                 Arguments.of( //
                         "<PACKAGE_NAME>.builder", //
                         "", //
-                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PUBLIC, Visibility.PACKAGE_PRIVATE}, //
+                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PACKAGE_PRIVATE, Visibility.PUBLIC, Visibility.PACKAGE_PRIVATE}, //
                         ImmutableSortedSet.of(
                                 publicSetter, //
                                 SimpleSetter.builder() //
@@ -169,7 +169,7 @@ class BuilderMetadataServiceImplTest {
                 Arguments.of( //
                         "<PACKAGE_NAME>", //
                         "", //
-                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PUBLIC, Visibility.PACKAGE_PRIVATE}, //
+                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PACKAGE_PRIVATE, Visibility.PUBLIC, Visibility.PACKAGE_PRIVATE}, //
                         ImmutableSortedSet.of(
                                 publicSetter, //
                                 SimpleSetter.builder() //
@@ -187,7 +187,7 @@ class BuilderMetadataServiceImplTest {
                                 .builtType(BuilderMetadata.BuiltType.builder() //
                                         .type(PackagePrivateConstructor.class) //
                                         .location(null) //
-                                        .accessibleNonArgsConstructor(false) //
+                                        .accessibleNonArgsConstructor(true) //
                                         .setter(publicSetter) //
                                         .setter(SimpleSetter.builder() //
                                                 .methodName("setPackagePrivate") //
@@ -201,7 +201,7 @@ class BuilderMetadataServiceImplTest {
                 Arguments.of( //
                         "io.github.tobi.laa.reflective.fluent.builders.test.models.visibility", //
                         "", //
-                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PRIVATE, Visibility.PACKAGE_PRIVATE}, //
+                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PACKAGE_PRIVATE, Visibility.PRIVATE, Visibility.PACKAGE_PRIVATE}, //
                         ImmutableSortedSet.of(
                                 publicSetter, //
                                 SimpleSetter.builder() //
@@ -219,7 +219,7 @@ class BuilderMetadataServiceImplTest {
                                 .builtType(BuilderMetadata.BuiltType.builder() //
                                         .type(PackagePrivateConstructor.class) //
                                         .location(null) //
-                                        .accessibleNonArgsConstructor(false) //
+                                        .accessibleNonArgsConstructor(true) //
                                         .setter(SimpleSetter.builder() //
                                                 .methodName("setPackagePrivate") //
                                                 .paramName("packagePrivate") //

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
@@ -18,6 +18,10 @@ public class PackagePrivateBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  public static PackagePrivateBuilder newInstance() {
+    return new PackagePrivateBuilder(null);
+  }
+
   public static PackagePrivateBuilder thatModifies(final PackagePrivate objectToModify) {
     Objects.requireNonNull(objectToModify);
     return new PackagePrivateBuilder(objectToModify);
@@ -30,6 +34,9 @@ public class PackagePrivateBuilder {
   }
 
   public PackagePrivate build() {
+    if (objectToBuild == null) {
+      objectToBuild = new PackagePrivate();
+    }
     if (callSetterFor.intField) {
       objectToBuild.setIntField(fieldValue.intField);
     }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
@@ -18,6 +18,10 @@ public class PackagePrivateConstructorBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  public static PackagePrivateConstructorBuilder newInstance() {
+    return new PackagePrivateConstructorBuilder(null);
+  }
+
   public static PackagePrivateConstructorBuilder thatModifies(
       final PackagePrivateConstructor objectToModify) {
     Objects.requireNonNull(objectToModify);
@@ -37,6 +41,9 @@ public class PackagePrivateConstructorBuilder {
   }
 
   public PackagePrivateConstructor build() {
+    if (objectToBuild == null) {
+      objectToBuild = new PackagePrivateConstructor();
+    }
     if (callSetterFor.intField) {
       objectToBuild.setIntField(fieldValue.intField);
     }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
@@ -18,6 +18,10 @@ public class ProtectedConstructorBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  public static ProtectedConstructorBuilder newInstance() {
+    return new ProtectedConstructorBuilder(null);
+  }
+
   public static ProtectedConstructorBuilder thatModifies(
       final ProtectedConstructor objectToModify) {
     Objects.requireNonNull(objectToModify);
@@ -31,6 +35,9 @@ public class ProtectedConstructorBuilder {
   }
 
   public ProtectedConstructor build() {
+    if (objectToBuild == null) {
+      objectToBuild = new ProtectedConstructor();
+    }
     if (callSetterFor.intField) {
       objectToBuild.setIntField(fieldValue.intField);
     }


### PR DESCRIPTION
Fixes #107 

---

- [x] All commit messages contain meaningful descriptions.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [ ] Build pipeline passes.
