### PR TITLE
Feature/109 name collisions with pre existing builders

### DIFF
--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/ClassService.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/ClassService.java
@@ -58,4 +58,15 @@ public interface ClassService {
      * @return The location of the file that contains {@code clazz}, if it could be determined.
      */
     Optional<Path> determineClassLocation(final Class<?> clazz);
+
+    /**
+     * <p>
+     * Checks whether a class with the fully qualified {@code className} exists on the current classpath.
+     * </p>
+     *
+     * @param className Fully qualified {@code className} which to check for existence.
+     * @return {@code true} if a class with the fully qualified {@code className} exists on the current classpath,
+     * {@code false} otherwise.
+     */
+    boolean existsOnClasspath(final String className);
 }

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
@@ -53,7 +53,7 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
         final String builderPackage = resolveBuilderPackage(clazz);
         return BuilderMetadata.builder() //
                 .packageName(builderPackage) //
-                .name(clazz.getSimpleName() + properties.getBuilderSuffix()) //
+                .name(builderClassName(clazz, builderPackage)) //
                 .builtType(BuilderMetadata.BuiltType.builder() //
                         .type(clazz) //
                         .location(classService.determineClassLocation(clazz).orElse(null)) //
@@ -61,6 +61,16 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
                         .setters(gatherAndFilterAccessibleSettersAndAvoidNameCollisions(clazz, builderPackage))
                         .build()) //
                 .build();
+    }
+
+    private String builderClassName(final Class<?> clazz, final String builderPackage) {
+        var name = clazz.getSimpleName() + properties.getBuilderSuffix();
+        int count = 0;
+        while (classService.existsOnClasspath(builderPackage + '.' + name)) {
+            name = clazz.getSimpleName() + properties.getBuilderSuffix() + count;
+            count++;
+        }
+        return name;
     }
 
     private String resolveBuilderPackage(final Class<?> clazz) {

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImpl.java
@@ -115,4 +115,14 @@ class ClassServiceImpl implements ClassService {
             return path;
         }
     }
+
+    @Override
+    public boolean existsOnClasspath(final String className) {
+        try {
+            Class.forName(className, false, Thread.currentThread().getContextClassLoader());
+            return true;
+        } catch (final ClassNotFoundException e) {
+            return false;
+        }
+    }
 }

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
@@ -239,4 +239,21 @@ class ClassServiceImplTest {
         // Assert
         assertThrows(URISyntaxException.class, getLocationAsPath);
     }
+
+    @ParameterizedTest
+    @MethodSource
+    void testExistsOnClasspath(final String className, final boolean expected) {
+        // Act
+        final boolean actual = classServiceImpl.existsOnClasspath(className);
+        // Assert
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> testExistsOnClasspath() {
+        return Stream.of( //
+                Arguments.of("this.class.exists.not", false), //
+                Arguments.of("io.github.tobi.laa.reflective.fluent.builders.mojo.GenerateBuildersMojo", false), //
+                Arguments.of("java.lang.String", true), //
+                Arguments.of("io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService", true));
+    }
 }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
@@ -1,0 +1,55 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class BuiltClassAsMemberBuilder0 {
+  private BuiltClassAsMemberBuilder.BuiltClassAsMember objectToBuild;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  private BuiltClassAsMemberBuilder0(
+      final BuiltClassAsMemberBuilder.BuiltClassAsMember objectToBuild) {
+    this.objectToBuild = objectToBuild;
+  }
+
+  public static BuiltClassAsMemberBuilder0 newInstance() {
+    return new BuiltClassAsMemberBuilder0(null);
+  }
+
+  public static BuiltClassAsMemberBuilder0 thatModifies(
+      final BuiltClassAsMemberBuilder.BuiltClassAsMember objectToModify) {
+    Objects.requireNonNull(objectToModify);
+    return new BuiltClassAsMemberBuilder0(objectToModify);
+  }
+
+  public BuiltClassAsMemberBuilder0 aField(final int aField) {
+    fieldValue.aField = aField;
+    callSetterFor.aField = true;
+    return this;
+  }
+
+  public BuiltClassAsMemberBuilder.BuiltClassAsMember build() {
+    if (objectToBuild == null) {
+      objectToBuild = new BuiltClassAsMemberBuilder.BuiltClassAsMember();
+    }
+    if (callSetterFor.aField) {
+      objectToBuild.setAField(fieldValue.aField);
+    }
+    return objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean aField;
+  }
+
+  private class FieldValue {
+    int aField;
+  }
+}

--- a/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder.java
+++ b/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder.java
@@ -1,0 +1,24 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex;
+
+import lombok.Data;
+
+class BuiltClassAsMemberBuilder {
+
+    private int aField;
+
+    BuiltClassAsMemberBuilder aField(int aField) {
+        this.aField = aField;
+        return this;
+    }
+
+    BuiltClassAsMember build() {
+        final BuiltClassAsMember result = new BuiltClassAsMember();
+        result.setAField(aField);
+        return result;
+    }
+
+    @Data
+    static class BuiltClassAsMember {
+        private int aField;
+    }
+}


### PR DESCRIPTION
Fixes #109.

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [x] Build pipeline passes.
- [x] Test coverage is 100%.
