### PR TITLE
Feature/118 detection of existing builders broken

### DIFF
--- a/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/generator/api/JavaFileGeneratorIT.java
+++ b/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/generator/api/JavaFileGeneratorIT.java
@@ -82,6 +82,9 @@ class JavaFileGeneratorIT {
                         "    date = \"3333-03-13T00:00Z[UTC]\"\n" +
                         ")\n" +
                         "public class ClassWithGenericsBuilder<T> {\n" +
+                        "  /**\n" +
+                        "   * This field is solely used to be able to detect generated builders via reflection at a later stage.\n" +
+                        "   */\n" +
                         "  private boolean ______generatedByReflectiveFluentBuildersGenerator;\n" +
                         "\n" +
                         "  private ClassWithGenerics objectToBuild;\n" +

--- a/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/generator/api/JavaFileGeneratorIT.java
+++ b/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/generator/api/JavaFileGeneratorIT.java
@@ -82,6 +82,8 @@ class JavaFileGeneratorIT {
                         "    date = \"3333-03-13T00:00Z[UTC]\"\n" +
                         ")\n" +
                         "public class ClassWithGenericsBuilder<T> {\n" +
+                        "  private boolean ______generatedByReflectiveFluentBuildersGenerator;\n" +
+                        "\n" +
                         "  private ClassWithGenerics objectToBuild;\n" +
                         "\n" +
                         "  private final CallSetterFor callSetterFor = new CallSetterFor();\n" +

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/constants/BuilderConstants.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/constants/BuilderConstants.java
@@ -30,6 +30,13 @@ public final class BuilderConstants {
 
     /**
      * <p>
+     * Name of the marker field which is solely used to be able to detect generated builders via reflection at a later stage.
+     * </p>
+     */
+    public static final String GENERATED_BUILDER_MARKER_FIELD_NAME = "______generatedByReflectiveFluentBuildersGenerator";
+
+    /**
+     * <p>
      * Class and field name for the inner class which is added to every generated builder for encapsulating the actual
      * field values to avoid name collisions.
      * </p>

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGenerator.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGenerator.java
@@ -1,0 +1,25 @@
+package io.github.tobi.laa.reflective.fluent.builders.generator.impl;
+
+import com.squareup.javapoet.FieldSpec;
+import io.github.tobi.laa.reflective.fluent.builders.generator.api.FieldCodeGenerator;
+import io.github.tobi.laa.reflective.fluent.builders.model.BuilderMetadata;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderConstants.GENERATED_BUILDER_MARKER_FIELD_NAME;
+import static javax.lang.model.element.Modifier.PRIVATE;
+
+/**
+ * <p>
+ *     Generates an unused field with an unusual name that is solely used to be able to detect generated builders via reflection at a later stage.
+ * </p>
+ */
+@Named
+@Singleton
+class GeneratedBuilderMarkerFieldCodeGenerator implements FieldCodeGenerator {
+    @Override
+    public FieldSpec generate(final BuilderMetadata builderMetadata) {
+        return FieldSpec.builder(boolean.class, GENERATED_BUILDER_MARKER_FIELD_NAME, PRIVATE).build();
+    }
+}

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGenerator.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGenerator.java
@@ -12,7 +12,7 @@ import static javax.lang.model.element.Modifier.PRIVATE;
 
 /**
  * <p>
- *     Generates an unused field with an unusual name that is solely used to be able to detect generated builders via reflection at a later stage.
+ * Generates an unused field with an unusual name that is solely used to be able to detect generated builders via reflection at a later stage.
  * </p>
  */
 @Named
@@ -20,6 +20,8 @@ import static javax.lang.model.element.Modifier.PRIVATE;
 class GeneratedBuilderMarkerFieldCodeGenerator implements FieldCodeGenerator {
     @Override
     public FieldSpec generate(final BuilderMetadata builderMetadata) {
-        return FieldSpec.builder(boolean.class, GENERATED_BUILDER_MARKER_FIELD_NAME, PRIVATE).build();
+        return FieldSpec.builder(boolean.class, GENERATED_BUILDER_MARKER_FIELD_NAME, PRIVATE)
+                .addJavadoc("This field is solely used to be able to detect generated builders via reflection at a later stage.")
+                .build();
     }
 }

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/ClassService.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/ClassService.java
@@ -61,12 +61,15 @@ public interface ClassService {
 
     /**
      * <p>
-     * Checks whether a class with the fully qualified {@code className} exists on the current classpath.
+     * Attempts to load the class with the fully qualified {@code className} if it exists on the current classpath.
+     * Returns an {@link Optional#empty() empty Optional} if no such class exists.
      * </p>
      *
-     * @param className Fully qualified {@code className} which to check for existence.
-     * @return {@code true} if a class with the fully qualified {@code className} exists on the current classpath,
-     * {@code false} otherwise.
+     * @param className Fully qualified name of the class to attempt to load. Must not be {@code null}.
+     * @return The class with the fully qualified {@code className} if it exists on the current classpath, otherwise an
+     * {@link Optional#empty() empty Optional}.
+     * @throws ReflectionException If an error (<em>not</em> {@link ClassNotFoundException}) occurs while attempting to
+     *                             load {@code className}.
      */
-    boolean existsOnClasspath(final String className);
+    Optional<Class<?>> loadClass(final String className);
 }

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
@@ -1,6 +1,5 @@
 package io.github.tobi.laa.reflective.fluent.builders.service.impl;
 
-import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderConstants.GENERATED_BUILDER_MARKER_FIELD_NAME;
 import com.google.common.collect.ImmutableSortedSet;
 import io.github.tobi.laa.reflective.fluent.builders.model.BuilderMetadata;
 import io.github.tobi.laa.reflective.fluent.builders.model.Setter;
@@ -17,9 +16,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderConstants.GENERATED_BUILDER_MARKER_FIELD_NAME;
 import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderConstants.PACKAGE_PLACEHOLDER;
 import static io.github.tobi.laa.reflective.fluent.builders.model.Visibility.*;
 import static java.lang.reflect.Modifier.isStatic;

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImpl.java
@@ -120,12 +120,13 @@ class ClassServiceImpl implements ClassService {
     }
 
     @Override
-    public boolean existsOnClasspath(final String className) {
+    public Optional<Class<?>> loadClass(String className) {
         try {
-            Class.forName(className, false, classLoader);
-            return true;
+            return Optional.of(Class.forName(className, false, classLoader));
         } catch (final ClassNotFoundException e) {
-            return false;
+            return Optional.empty();
+        } catch (final LinkageError | SecurityException e) {
+            throw new ReflectionException("Error while attempting to load class " + className + '.', e);
         }
     }
 }

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGeneratorTest.java
@@ -28,8 +28,8 @@ class GeneratedBuilderMarkerFieldCodeGeneratorTest {
         // Assert
         assertThat(actual).isNotNull();
         assertThat(actual.toString())
-                .isEqualToIgnoringNewLines(String.format("" + //
-                                "/**\n" + //
+                .isEqualToIgnoringNewLines(String.format( //
+                        "/**\n" + //
                                 " * This field is solely used to be able to detect generated builders via reflection at a later stage.\n" + //
                                 " */\n" + //
                                 "private boolean %s;\n", //

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGeneratorTest.java
@@ -1,0 +1,32 @@
+package io.github.tobi.laa.reflective.fluent.builders.generator.impl;
+
+import com.squareup.javapoet.FieldSpec;
+import io.github.tobi.laa.reflective.fluent.builders.model.BuilderMetadata;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.simple.SimpleClass;
+import org.junit.jupiter.api.Test;
+
+import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderConstants.GENERATED_BUILDER_MARKER_FIELD_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GeneratedBuilderMarkerFieldCodeGeneratorTest {
+
+    private final GeneratedBuilderMarkerFieldCodeGenerator generator = new GeneratedBuilderMarkerFieldCodeGenerator();
+
+    @Test
+    void testGenerate() {
+        // Arrange
+        final BuilderMetadata builderMetadata = BuilderMetadata.builder() //
+                .packageName("com.github.tobi.laa.reflective.fluent.builders.test.models.simple") //
+                .name("SimpleClassBuilder") //
+                .builtType(BuilderMetadata.BuiltType.builder() //
+                        .type(SimpleClass.class) //
+                        .accessibleNonArgsConstructor(true) //
+                        .build()) //
+                .build();
+        // Act
+        final FieldSpec actual = generator.generate(builderMetadata);
+        // Assert
+        assertThat(actual).isNotNull();
+        assertThat(actual.toString()).isEqualToIgnoringNewLines(String.format("private boolean %s;\n", GENERATED_BUILDER_MARKER_FIELD_NAME));
+    }
+}

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/GeneratedBuilderMarkerFieldCodeGeneratorTest.java
@@ -27,6 +27,12 @@ class GeneratedBuilderMarkerFieldCodeGeneratorTest {
         final FieldSpec actual = generator.generate(builderMetadata);
         // Assert
         assertThat(actual).isNotNull();
-        assertThat(actual.toString()).isEqualToIgnoringNewLines(String.format("private boolean %s;\n", GENERATED_BUILDER_MARKER_FIELD_NAME));
+        assertThat(actual.toString())
+                .isEqualToIgnoringNewLines(String.format("" + //
+                                "/**\n" + //
+                                " * This field is solely used to be able to detect generated builders via reflection at a later stage.\n" + //
+                                " */\n" + //
+                                "private boolean %s;\n", //
+                        GENERATED_BUILDER_MARKER_FIELD_NAME));
     }
 }

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
@@ -3,6 +3,7 @@ package io.github.tobi.laa.reflective.fluent.builders.service.impl;
 import com.google.common.reflect.ClassPath;
 import io.github.tobi.laa.reflective.fluent.builders.exception.ReflectionException;
 import io.github.tobi.laa.reflective.fluent.builders.props.api.BuildersProperties;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.*;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.second.SecondSuperClassInDifferentPackage;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.nested.NestedMarker;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -35,14 +37,14 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static java.lang.ClassLoader.getSystemClassLoader;
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ClassServiceImplTest {
@@ -54,7 +56,7 @@ class ClassServiceImplTest {
 
     @BeforeEach
     void init() {
-        classServiceImpl = new ClassServiceImpl(properties, ClassLoader.getSystemClassLoader());
+        classServiceImpl = new ClassServiceImpl(properties, getSystemClassLoader());
     }
 
     @Test
@@ -244,20 +246,59 @@ class ClassServiceImplTest {
         assertThrows(URISyntaxException.class, getLocationAsPath);
     }
 
-    @ParameterizedTest
-    @MethodSource
-    void testExistsOnClasspath(final String className, final boolean expected) {
+    @Test
+    void testLoadClassNull() {
+        // Arrange
+        final String className = null;
+        final var classLoader = spy(getSystemClassLoader());
+        classServiceImpl = new ClassServiceImpl(properties, classLoader);
         // Act
-        final boolean actual = classServiceImpl.existsOnClasspath(className);
+        final ThrowingCallable loadClass = () -> classServiceImpl.loadClass(className);
         // Assert
-        assertThat(actual).isEqualTo(expected);
+        assertThatThrownBy(loadClass).isExactlyInstanceOf(NullPointerException.class);
+        verifyNoInteractions(classLoader);
     }
 
-    private static Stream<Arguments> testExistsOnClasspath() {
+    @ParameterizedTest
+    @ValueSource(classes = {LinkageError.class, SecurityException.class})
+    @SneakyThrows
+    void testLoadClassException(final Class<? extends Throwable> causeType) {
+        // Arrange
+        final var className = "does.not.matter";
+        final var cause = causeType.getDeclaredConstructor(String.class).newInstance("Thrown in unit test.");
+        final var classLoader = spy(getSystemClassLoader());
+        doThrow(cause).when(classLoader).loadClass(anyString());
+        classServiceImpl = new ClassServiceImpl(properties, classLoader);
+        // Act
+        final ThrowingCallable loadClass = () -> classServiceImpl.loadClass(className);
+        // Assert
+        assertThatThrownBy(loadClass) //
+                .isExactlyInstanceOf(ReflectionException.class) //
+                .hasMessage("Error while attempting to load class does.not.matter.") //
+                .hasCause(cause);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"this.class.exists.not", "io.github.tobi.laa.reflective.fluent.builders.mojo.GenerateBuildersMojo"})
+    void testLoadClassEmpty(final String className) {
+        // Act
+        final Optional<Class<?>> actual = classServiceImpl.loadClass(className);
+        // Assert
+        assertThat(actual).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testLoadClass(final String className, final Class<?> expected) {
+        // Act
+        final Optional<Class<?>> actual = classServiceImpl.loadClass(className);
+        // Assert
+        assertThat(actual).get().isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> testLoadClass() {
         return Stream.of( //
-                Arguments.of("this.class.exists.not", false), //
-                Arguments.of("io.github.tobi.laa.reflective.fluent.builders.mojo.GenerateBuildersMojo", false), //
-                Arguments.of("java.lang.String", true), //
-                Arguments.of("io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService", true));
+                Arguments.of("java.lang.String", String.class), //
+                Arguments.of("io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService", ClassService.class));
     }
 }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/custom-hierarchy-collection-excludes/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/custom-hierarchy-collection-excludes/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithHierarchyBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private ClassWithHierarchy objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/custom-hierarchy-collection-excludes/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/custom-hierarchy-collection-excludes/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithHierarchyBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private ClassWithHierarchy objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class BuiltClassAsMemberBuilder0 {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private BuiltClassAsMemberBuilder.BuiltClassAsMember objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class BuiltClassAsMemberBuilder0 {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private BuiltClassAsMemberBuilder.BuiltClassAsMember objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithBuilderExistingBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithBuilderExistingBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithBuilderExistingBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private ClassWithBuilderExisting objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithBuilderExistingBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithBuilderExistingBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithBuilderExistingBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private ClassWithBuilderExisting objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
@@ -23,6 +23,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithCollectionsBuilder<T, U> {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private ClassWithCollections objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
@@ -23,6 +23,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithCollectionsBuilder<T, U> {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private ClassWithCollections objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithGenericsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithGenericsBuilder.java
@@ -11,6 +11,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithGenericsBuilder<T> {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private ClassWithGenerics objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithGenericsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithGenericsBuilder.java
@@ -11,6 +11,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithGenericsBuilder<T> {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private ClassWithGenerics objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/GetAndAddBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/GetAndAddBuilder.java
@@ -11,6 +11,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class GetAndAddBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private GetAndAdd objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/GetAndAddBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/GetAndAddBuilder.java
@@ -11,6 +11,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class GetAndAddBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private GetAndAdd objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithHierarchyBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private ClassWithHierarchy objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ClassWithHierarchyBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private ClassWithHierarchy objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/FirstSuperClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/FirstSuperClassBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class FirstSuperClassBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private FirstSuperClass objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/FirstSuperClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/FirstSuperClassBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class FirstSuperClassBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private FirstSuperClass objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericChildBuilder.java
@@ -14,6 +14,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class GenericChildBuilder<S extends Number, T> {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private GenericChild objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericChildBuilder.java
@@ -14,6 +14,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class GenericChildBuilder<S extends Number, T> {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private GenericChild objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericGrandChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericGrandChildBuilder.java
@@ -15,6 +15,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class GenericGrandChildBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private GenericGrandChild objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericGrandChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericGrandChildBuilder.java
@@ -15,6 +15,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class GenericGrandChildBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private GenericGrandChild objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericParentBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericParentBuilder.java
@@ -12,6 +12,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class GenericParentBuilder<R, S, T> {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private GenericParent objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericParentBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericParentBuilder.java
@@ -12,6 +12,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class GenericParentBuilder<R, S, T> {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private GenericParent objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/second/SecondSuperClassInDifferentPackageBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/second/SecondSuperClassInDifferentPackageBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class SecondSuperClassInDifferentPackageBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private SecondSuperClassInDifferentPackage objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/second/SecondSuperClassInDifferentPackageBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/second/SecondSuperClassInDifferentPackageBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class SecondSuperClassInDifferentPackageBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private SecondSuperClassInDifferentPackage objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
@@ -16,6 +16,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PersonBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private Person objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
@@ -16,6 +16,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PersonBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private Person objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PetBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PetBuilder.java
@@ -11,6 +11,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PetBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private Pet objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PetBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PetBuilder.java
@@ -11,6 +11,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PetBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private Pet objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/EntryBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/EntryBuilder.java
@@ -9,6 +9,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class EntryBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private PersonJaxb.Relations.Entry objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/EntryBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/EntryBuilder.java
@@ -9,6 +9,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class EntryBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private PersonJaxb.Relations.Entry objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PersonJaxbBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PersonJaxbBuilder.java
@@ -12,6 +12,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PersonJaxbBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private PersonJaxb objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PersonJaxbBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PersonJaxbBuilder.java
@@ -12,6 +12,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PersonJaxbBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private PersonJaxb objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PetJaxbBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PetJaxbBuilder.java
@@ -11,6 +11,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PetJaxbBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private PetJaxb objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PetJaxbBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PetJaxbBuilder.java
@@ -11,6 +11,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PetJaxbBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private PetJaxb objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/RelationsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/RelationsBuilder.java
@@ -10,6 +10,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class RelationsBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private PersonJaxb.Relations objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/RelationsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/RelationsBuilder.java
@@ -10,6 +10,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class RelationsBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private PersonJaxb.Relations objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPackagePrivateLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPackagePrivateLevelOneBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedPackagePrivateLevelOneBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private TopLevelClass.NestedPackagePrivateLevelOne objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPackagePrivateLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPackagePrivateLevelOneBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedPackagePrivateLevelOneBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private TopLevelClass.NestedPackagePrivateLevelOne objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedProtectedLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedProtectedLevelOneBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedProtectedLevelOneBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private TopLevelClass.NestedProtectedLevelOne objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedProtectedLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedProtectedLevelOneBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedProtectedLevelOneBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private TopLevelClass.NestedProtectedLevelOne objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelOneBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedPublicLevelOneBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private TopLevelClass.NestedPublicLevelOne objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelOneBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedPublicLevelOneBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private TopLevelClass.NestedPublicLevelOne objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelThreeBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelThreeBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedPublicLevelThreeBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private TopLevelClass.NestedPublicLevelOne.NestedPublicLevelTwo.NestedPublicLevelThree objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelThreeBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelThreeBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedPublicLevelThreeBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private TopLevelClass.NestedPublicLevelOne.NestedPublicLevelTwo.NestedPublicLevelThree objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelTwoBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelTwoBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedPublicLevelTwoBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private TopLevelClass.NestedPublicLevelOne.NestedPublicLevelTwo objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelTwoBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelTwoBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class NestedPublicLevelTwoBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private TopLevelClass.NestedPublicLevelOne.NestedPublicLevelTwo objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/TopLevelClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/TopLevelClassBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class TopLevelClassBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private TopLevelClass objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/TopLevelClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/TopLevelClassBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class TopLevelClassBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private TopLevelClass objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
@@ -10,6 +10,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class SimpleClassBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private SimpleClass objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
@@ -10,6 +10,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class SimpleClassBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private SimpleClass objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ChildBuilder.java
@@ -9,6 +9,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ChildBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private Child objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ChildBuilder.java
@@ -9,6 +9,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ChildBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private Child objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ParentBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ParentBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ParentBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private Parent objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ParentBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ParentBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ParentBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private Parent objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PackagePrivateBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private PackagePrivate objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PackagePrivateBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private PackagePrivate objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PackagePrivateConstructorBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private PackagePrivateConstructor objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PackagePrivateConstructorBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private PackagePrivateConstructor objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PrivateConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PrivateConstructorBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PrivateConstructorBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private PrivateConstructor objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PrivateConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PrivateConstructorBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class PrivateConstructorBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private PrivateConstructor objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ProtectedConstructorBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private ProtectedConstructor objectToBuild;

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class ProtectedConstructorBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private ProtectedConstructor objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/SettersWithDifferentVisibilityBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/SettersWithDifferentVisibilityBuilder.java
@@ -8,6 +8,8 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class SettersWithDifferentVisibilityBuilder {
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
   private SettersWithDifferentVisibility objectToBuild;
 
   private final CallSetterFor callSetterFor = new CallSetterFor();

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/SettersWithDifferentVisibilityBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/SettersWithDifferentVisibilityBuilder.java
@@ -8,6 +8,9 @@ import javax.annotation.processing.Generated;
     date = "3333-03-13T00:00Z[UTC]"
 )
 public class SettersWithDifferentVisibilityBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
   private boolean ______generatedByReflectiveFluentBuildersGenerator;
 
   private SettersWithDifferentVisibility objectToBuild;


### PR DESCRIPTION
Fixes #118

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [ ] Build pipeline passes.
- [ ] Test coverage is 100%.
