### PR TITLE
Feature/136 classloader is reused across multiple executions of a multi module project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.tobi-laa</groupId>
     <artifactId>reflective-fluent-builders</artifactId>
@@ -69,7 +70,7 @@
         <guava.version>32.1.2-jre</guava.version>
         <jsr-330.version>1</jsr-330.version>
         <guice.version>6.0.0</guice.version>
-	<sisu.version>0.9.0.M2</sisu.version>
+        <sisu.version>0.9.0.M2</sisu.version>
         <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImpl.java
@@ -9,6 +9,7 @@ import lombok.SneakyThrows;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -40,7 +41,7 @@ class ClassServiceImpl implements ClassService {
     private final BuildersProperties properties;
 
     @lombok.NonNull
-    private final ClassLoader classLoader;
+    private final Provider<ClassLoader> classLoaderProvider;
 
     @Override
     public List<Class<?>> collectFullClassHierarchy(final Class<?> clazz) {
@@ -66,7 +67,7 @@ class ClassServiceImpl implements ClassService {
     public Set<Class<?>> collectClassesRecursively(final String packageName) {
         Objects.requireNonNull(packageName);
         try {
-            return ClassPath.from(classLoader) //
+            return ClassPath.from(classLoaderProvider.get()) //
                     .getTopLevelClassesRecursive(packageName) //
                     .stream() //
                     .map(ClassPath.ClassInfo::load) //
@@ -122,7 +123,7 @@ class ClassServiceImpl implements ClassService {
     @Override
     public Optional<Class<?>> loadClass(String className) {
         try {
-            return Optional.of(Class.forName(className, false, classLoader));
+            return Optional.of(Class.forName(className, false, classLoaderProvider.get()));
         } catch (final ClassNotFoundException e) {
             return Optional.empty();
         } catch (final LinkageError | SecurityException e) {

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
@@ -58,7 +58,7 @@ class ClassServiceImplTest {
 
     @BeforeEach
     void init() {
-        classServiceImpl = new ClassServiceImpl(properties, getSystemClassLoader());
+        classServiceImpl = new ClassServiceImpl(properties, ClassLoader::getSystemClassLoader);
     }
 
     @Test
@@ -253,7 +253,7 @@ class ClassServiceImplTest {
         // Arrange
         final String className = null;
         final var classLoader = spy(getSystemClassLoader());
-        classServiceImpl = new ClassServiceImpl(properties, classLoader);
+        classServiceImpl = new ClassServiceImpl(properties, () -> classLoader);
         // Act
         final ThrowingCallable loadClass = () -> classServiceImpl.loadClass(className);
         // Assert
@@ -269,7 +269,7 @@ class ClassServiceImplTest {
         final var className = "does.not.matter";
         final var cause = causeType.getDeclaredConstructor(String.class).newInstance("Thrown in unit test.");
         final var classLoader = new ThrowingClassLoader(cause);
-        classServiceImpl = new ClassServiceImpl(properties, classLoader);
+        classServiceImpl = new ClassServiceImpl(properties, () -> classLoader);
         // Act
         final ThrowingCallable loadClass = () -> classServiceImpl.loadClass(className);
         // Assert

--- a/reflective-fluent-builders-maven-plugin/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.github.tobi-laa</groupId>

--- a/reflective-fluent-builders-maven-plugin/src/it/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT.java
@@ -446,4 +446,31 @@ class GenerateBuildersMojoIT {
                             "All builders are up-to-date, skipping generation.");
         }
     }
+
+    @Nested
+    @MavenRepository(MAVEN_SHARED_LOCAL_CACHE)
+    class MultiModuleBuild {
+
+        @MavenTest
+        void multiModuleBuild(final MavenExecutionResult result) {
+            final var expectedBuildersRootDir = Paths.get("src", "it", "resources", "expected-builders", "multi-module-project");
+            assertThat(result).isSuccessful();
+            assertThat(result) //
+                    .project() //
+                    .withModule("module1") //
+                    .hasTarget() //
+                    .has(ContainsBuildersCondition.expectedBuilder( //
+                            "io.github.tobi.laa.reflective.fluent.builders.test.models.DogBuilder", //
+                            true, //
+                            expectedBuildersRootDir.resolve("module1")));
+            assertThat(result) //
+                    .project() //
+                    .withModule("module2") //
+                    .hasTarget() //
+                    .has(ContainsBuildersCondition.expectedBuilder( //
+                            "io.github.tobi.laa.reflective.fluent.builders.test.models.CatBuilder", //
+                            true, //
+                            expectedBuildersRootDir.resolve("module2")));
+        }
+    }
 }

--- a/reflective-fluent-builders-maven-plugin/src/it/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders.java
@@ -34,4 +34,12 @@ class GenerateExpectedBuilders {
     void generateExpectedBuilders(final MavenExecutionResult result) {
         assertThat(result).isSuccessful().project().hasTarget();
     }
+
+    @MavenTest
+    @MavenDebug
+    void generateExpectedBuildersMultiModuleProject(final MavenExecutionResult result) {
+        assertThat(result).isSuccessful();
+        assertThat(result).project().withModule("module1").hasTarget();
+        assertThat(result).project().withModule("module2").hasTarget();
+    }
 }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module1/io/github/tobi/laa/reflective/fluent/builders/test/models/DogBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module1/io/github/tobi/laa/reflective/fluent/builders/test/models/DogBuilder.java
@@ -1,0 +1,59 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models;
+
+import java.lang.String;
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class DogBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
+  private Dog objectToBuild;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  private DogBuilder(final Dog objectToBuild) {
+    this.objectToBuild = objectToBuild;
+  }
+
+  public static DogBuilder newInstance() {
+    return new DogBuilder(null);
+  }
+
+  public static DogBuilder thatModifies(final Dog objectToModify) {
+    Objects.requireNonNull(objectToModify);
+    return new DogBuilder(objectToModify);
+  }
+
+  public DogBuilder name(final String name) {
+    fieldValue.name = name;
+    callSetterFor.name = true;
+    return this;
+  }
+
+  public Dog build() {
+    if (objectToBuild == null) {
+      objectToBuild = new Dog();
+    }
+    if (callSetterFor.name) {
+      objectToBuild.setName(fieldValue.name);
+    }
+    return objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean name;
+  }
+
+  private class FieldValue {
+    String name;
+  }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module2/io/github/tobi/laa/reflective/fluent/builders/test/models/CatBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module2/io/github/tobi/laa/reflective/fluent/builders/test/models/CatBuilder.java
@@ -1,0 +1,59 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models;
+
+import java.lang.String;
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class CatBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
+  private Cat objectToBuild;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  private CatBuilder(final Cat objectToBuild) {
+    this.objectToBuild = objectToBuild;
+  }
+
+  public static CatBuilder newInstance() {
+    return new CatBuilder(null);
+  }
+
+  public static CatBuilder thatModifies(final Cat objectToModify) {
+    Objects.requireNonNull(objectToModify);
+    return new CatBuilder(objectToModify);
+  }
+
+  public CatBuilder fur(final String fur) {
+    fieldValue.fur = fur;
+    callSetterFor.fur = true;
+    return this;
+  }
+
+  public Cat build() {
+    if (objectToBuild == null) {
+      objectToBuild = new Cat();
+    }
+    if (callSetterFor.fur) {
+      objectToBuild.setFur(fieldValue.fur);
+    }
+    return objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean fur;
+  }
+
+  private class FieldValue {
+    String fur;
+  }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/module1/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/module1/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.tobi-laa</groupId>
+        <artifactId>reflective-fluent-builders-it</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>module1</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.tobi-laa</groupId>
+                <artifactId>reflective-fluent-builders-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate-builders-with-default-config-for-module1</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate-builders</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>
+                                    <packageName>
+                                        io.github.tobi.laa.reflective.fluent.builders.test.models
+                                    </packageName>
+                                </include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/module1/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/Dog.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/module1/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/Dog.java
@@ -1,0 +1,10 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models;
+
+class Dog {
+
+    private String name;
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/module2/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/module2/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.tobi-laa</groupId>
+        <artifactId>reflective-fluent-builders-it</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>module2</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.tobi-laa</groupId>
+                <artifactId>reflective-fluent-builders-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate-builders-with-default-config-for-module2</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>generate-builders</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>
+                                    <packageName>
+                                        io.github.tobi.laa.reflective.fluent.builders.test.models
+                                    </packageName>
+                                </include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/module2/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/Cat.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/module2/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/Cat.java
@@ -1,0 +1,10 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models;
+
+class Cat {
+
+    private String fur;
+
+    public void setFur(final String fur) {
+        this.fur = fur;
+    }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/MultiModuleBuild/multiModuleBuild/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.tobi-laa</groupId>
+        <artifactId>reflective-fluent-builders</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>reflective-fluent-builders-it</artifactId>
+    <description>Integration test for the maven plugin</description>
+    <packaging>pom</packaging>
+    <modules>
+        <module>module1</module>
+        <module>module2</module>
+    </modules>
+</project>

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/module1/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/module1/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.tobi-laa</groupId>
+        <artifactId>reflective-fluent-builders-it</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>module1</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.tobi-laa</groupId>
+                <artifactId>reflective-fluent-builders-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate-builders-with-default-config-for-module1</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>generate-builders</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>
+                                    <packageName>
+                                        io.github.tobi.laa.reflective.fluent.builders.test.models
+                                    </packageName>
+                                </include>
+                            </includes>
+                            <target>
+                                ${project.basedir}/${it.resources.directory}/expected-builders/multi-module-project/module1
+                            </target>
+                            <addCompileSourceRoot>false</addCompileSourceRoot>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/module1/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/Dog.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/module1/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/Dog.java
@@ -1,0 +1,10 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models;
+
+class Dog {
+
+    private String name;
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/module2/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/module2/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.tobi-laa</groupId>
+        <artifactId>reflective-fluent-builders-it</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>module2</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.tobi-laa</groupId>
+                <artifactId>reflective-fluent-builders-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate-builders-with-default-config-for-module2</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>generate-builders</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>
+                                    <packageName>
+                                        io.github.tobi.laa.reflective.fluent.builders.test.models
+                                    </packageName>
+                                </include>
+                            </includes>
+                            <target>
+                                ${project.basedir}/${it.resources.directory}/expected-builders/multi-module-project/module2
+                            </target>
+                            <addCompileSourceRoot>false</addCompileSourceRoot>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/module2/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/Cat.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/module2/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/Cat.java
@@ -1,0 +1,10 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models;
+
+class Cat {
+
+    private String fur;
+
+    public void setFur(final String fur) {
+        this.fur = fur;
+    }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuildersMultiModuleProject/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.tobi-laa</groupId>
+        <artifactId>reflective-fluent-builders</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>reflective-fluent-builders-it</artifactId>
+    <description>Generate expected builders for integration tests of the maven plugin</description>
+    <packaging>pom</packaging>
+    <modules>
+        <module>module1</module>
+        <module>module2</module>
+    </modules>
+</project>

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/ClassLoaderProvider.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/ClassLoaderProvider.java
@@ -3,7 +3,6 @@ package io.github.tobi.laa.reflective.fluent.builders.mojo;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 
 import javax.inject.Inject;
@@ -31,9 +30,6 @@ class ClassLoaderProvider extends AbstractLogEnabled implements Provider<ClassLo
     @lombok.NonNull
     private final MavenBuild mavenBuild;
 
-    @lombok.NonNull
-    private final MavenProject mavenProject;
-
     @Override
     public ClassLoader get() {
         return new URLClassLoader(getClasspathElementUrls(), getSystemClassLoader());
@@ -51,11 +47,7 @@ class ClassLoaderProvider extends AbstractLogEnabled implements Provider<ClassLo
 
     private List<String> getClasspathElements() {
         try {
-            if (mavenBuild.isTestPhase()) {
-                return mavenProject.getTestClasspathElements();
-            } else {
-                return mavenProject.getCompileClasspathElements();
-            }
+            return mavenBuild.getClasspathElements();
         } catch (final DependencyResolutionRequiredException e) {
             throw new ClassLoaderConstructionException("Error while resolving dependencies of maven project.", e);
         }
@@ -75,6 +67,8 @@ class ClassLoaderProvider extends AbstractLogEnabled implements Provider<ClassLo
     }
 
     static class ClassLoaderConstructionException extends RuntimeException {
+
+        private static final long serialVersionUID = -8178484321714698102L;
 
         private ClassLoaderConstructionException(final String message, final Throwable cause) {
             super(message, cause);

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/ClassLoaderProvider.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/ClassLoaderProvider.java
@@ -1,5 +1,6 @@
 package io.github.tobi.laa.reflective.fluent.builders.mojo;
 
+import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.project.MavenProject;
@@ -23,6 +24,7 @@ import static java.lang.ClassLoader.getSystemClassLoader;
  * </p>
  */
 @Named
+@Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class ClassLoaderProvider extends AbstractLogEnabled implements Provider<ClassLoader> {
 

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/Closer.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/Closer.java
@@ -41,7 +41,7 @@ class Closer extends AbstractLogEnabled {
 
         private static final long serialVersionUID = -7002501270233855148L;
 
-        private CloseException(final String message, final Throwable cause) {
+        CloseException(final String message, final Throwable cause) {
             super(message, cause);
         }
     }

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/Closer.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/Closer.java
@@ -1,6 +1,5 @@
 package io.github.tobi.laa.reflective.fluent.builders.mojo;
 
-import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 
 import javax.inject.Named;
@@ -24,17 +23,26 @@ class Closer extends AbstractLogEnabled {
      * </p>
      *
      * @param object The object to be closed if it implements {@link Closeable}. Must not be {@code null}.
-     * @throws MojoExecutionException In case an {@link IOException error} occurs while attempting to close {@code classLoader}.
+     * @throws CloseException In case an {@link IOException error} occurs while attempting to close {@code classLoader}.
      */
-    <T> void closeIfCloseable(final T object) throws MojoExecutionException {
+    <T> void closeIfCloseable(final T object) {
         if (object instanceof Closeable) {
             try {
                 ((Closeable) object).close();
             } catch (final IOException e) {
-                throw new MojoExecutionException("Error while attempting to close " + object.getClass() + '.', e);
+                throw new CloseException("Error while attempting to close " + object.getClass() + '.', e);
             }
         } else {
             getLogger().debug("Not closing " + object + " of type " + object.getClass() + " as it does not implements Closeable.");
+        }
+    }
+
+    static class CloseException extends RuntimeException {
+
+        private static final long serialVersionUID = -7002501270233855148L;
+
+        private CloseException(final String message, final Throwable cause) {
+            super(message, cause);
         }
     }
 }

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
@@ -12,12 +12,15 @@ import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import lombok.RequiredArgsConstructor;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.build.BuildContext;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -468,5 +471,47 @@ public class GenerateBuildersMojo extends AbstractMojo {
     @SuppressWarnings("unused")
     public void setAddCompileSourceRoot(final boolean addCompileSourceRoot) {
         params.setAddCompileSourceRoot(addCompileSourceRoot);
+    }
+
+    /**
+     * <p>
+     * (Re-)Injects {@code buildContext} into components depending on it. This is mainly to circumvent bugs in multi module
+     * projects where dependencies are being re-used across executions.
+     * </p>
+     *
+     * @param buildContext (New) {@link BuildContext} to inject into components depending on it.
+     */
+    @Inject
+    @SuppressWarnings("unused")
+    public void setBuildContext(final BuildContext buildContext) {
+        mavenBuild.setBuildContext(buildContext);
+    }
+
+    /**
+     * <p>
+     * (Re-)Injects {@code mavenProject} into components depending on it. This is mainly to circumvent bugs in multi module
+     * projects where dependencies are being re-used across executions.
+     * </p>
+     *
+     * @param mavenProject (New) {@link MavenProject} to inject into components depending on it.
+     */
+    @Inject
+    @SuppressWarnings("unused")
+    public void setMavenProject(final MavenProject mavenProject) {
+        mavenBuild.setMavenProject(mavenProject);
+    }
+
+    /**
+     * <p>
+     * (Re-)Injects {@code mojoExecution} into components depending on it. This is mainly to circumvent bugs in multi module
+     * projects where dependencies are being re-used across executions.
+     * </p>
+     *
+     * @param mojoExecution (New) {@link MojoExecution} to inject into components depending on it.
+     */
+    @Inject
+    @SuppressWarnings("unused")
+    public void setMojoExecution(final MojoExecution mojoExecution) {
+        mavenBuild.setMojoExecution(mojoExecution);
     }
 }

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
@@ -50,7 +50,7 @@ public class GenerateBuildersMojo extends AbstractMojo {
     private final MavenBuild mavenBuild;
 
     @lombok.NonNull
-    private final ClassLoader classLoader;
+    private final ClassLoaderProvider classLoaderProvider;
 
     @lombok.NonNull
     private final JavaFileGenerator javaFileGenerator;
@@ -60,9 +60,6 @@ public class GenerateBuildersMojo extends AbstractMojo {
 
     @lombok.NonNull
     private final BuilderMetadataService builderMetadataService;
-
-    @lombok.NonNull
-    private final Closer closer;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -81,8 +78,8 @@ public class GenerateBuildersMojo extends AbstractMojo {
         closeClassLoader();
     }
 
-    private void closeClassLoader() throws MojoExecutionException {
-        closer.closeIfCloseable(classLoader);
+    private void closeClassLoader() {
+        classLoaderProvider.closeAndDisposeOfClassLoader();
     }
 
     private void logMavenParams() {
@@ -122,8 +119,8 @@ public class GenerateBuildersMojo extends AbstractMojo {
 
     private Class<?> loadClass(final String className) throws MojoExecutionException {
         try {
-            return classLoader.loadClass(className);
-        } catch (ClassNotFoundException e) {
+            return classLoaderProvider.get().loadClass(className);
+        } catch (final ClassNotFoundException e) {
             throw new MojoExecutionException("Unable to load class " + className, e);
         }
     }

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/MavenBuild.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/MavenBuild.java
@@ -1,6 +1,7 @@
 package io.github.tobi.laa.reflective.fluent.builders.mojo;
 
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -27,16 +28,17 @@ import static java.lang.Boolean.parseBoolean;
 @Singleton
 @Named
 @RequiredArgsConstructor(onConstructor_ = @Inject)
+@Setter
 class MavenBuild extends AbstractLogEnabled {
 
     @lombok.NonNull
-    private final BuildContext buildContext;
+    private BuildContext buildContext;
 
     @lombok.NonNull
-    private final MavenProject mavenProject;
+    private MavenProject mavenProject;
 
     @lombok.NonNull
-    private final MojoExecution mojoExecution;
+    private MojoExecution mojoExecution;
 
     boolean isIncremental() {
         return buildContext.isIncremental() || parseBoolean(System.getProperty("incrementalBuildForIntegrationTests"));

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/MavenBuild.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/MavenBuild.java
@@ -3,6 +3,7 @@ package io.github.tobi.laa.reflective.fluent.builders.mojo;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.build.BuildContext;
@@ -12,6 +13,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.File;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -79,5 +81,13 @@ class MavenBuild extends AbstractLogEnabled {
 
     Set<Artifact> getArtifacts() {
         return mavenProject.getArtifacts();
+    }
+
+    List<String> getClasspathElements() throws DependencyResolutionRequiredException {
+        if (isTestPhase()) {
+            return mavenProject.getTestClasspathElements();
+        } else {
+            return mavenProject.getCompileClasspathElements();
+        }
     }
 }

--- a/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/ClassLoaderProviderTest.java
+++ b/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/ClassLoaderProviderTest.java
@@ -141,8 +141,7 @@ class ClassLoaderProviderTest {
         // Act
         classLoader = provider.get();
         // Assert
-        assertThat(classLoader).isNotSameAs(oldClassLoader);
-        assertThat(classLoader).isNotNull().isInstanceOf(URLClassLoader.class);
+        assertThat(classLoader).isNotNull().isInstanceOf(URLClassLoader.class).isNotSameAs(oldClassLoader);
         assertThat(((URLClassLoader) classLoader).getURLs()).containsExactlyInAnyOrder(fileUrl("elem1"), fileUrl("elem2"));
         verify(logger, times(2)).debug("Attempt to add elem1 to ClassLoader.");
         verifyLogAddingToClassLoader("elem2");

--- a/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/ClassLoaderProviderTest.java
+++ b/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/ClassLoaderProviderTest.java
@@ -5,6 +5,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.codehaus.plexus.logging.Logger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,11 +17,13 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -38,11 +41,23 @@ class ClassLoaderProviderTest {
     private MavenBuild mavenBuild;
 
     @Mock
+    private Closer closer;
+
+    @Mock
     private Logger logger;
+
+    private ClassLoader classLoader;
 
     @BeforeEach
     void injectLogger() {
         provider.enableLogging(logger);
+    }
+
+    @AfterEach
+    void closeClassLoader() throws IOException {
+        if (classLoader != null) {
+            ((URLClassLoader) classLoader).close();
+        }
     }
 
     @Test
@@ -80,17 +95,19 @@ class ClassLoaderProviderTest {
     @ParameterizedTest
     @MethodSource
     @SneakyThrows
-    void testGet(final String[] classpathElements, final URL[] expectedUrls) {
+    void testGetNoOldClassLoader(final String[] classpathElements, final URL[] expectedUrls) {
         // Arrange
         mockClasspathElements(classpathElements);
         // Act
-        final var classLoader = provider.get();
+        classLoader = provider.get();
         // Assert
         assertThat(classLoader).isNotNull().isInstanceOf(URLClassLoader.class);
         assertThat(((URLClassLoader) classLoader).getURLs()).containsExactlyInAnyOrder(expectedUrls);
+        verifyLogAddingToClassLoader(classpathElements);
+        verifyNoMoreInteractions(logger);
     }
 
-    private static Stream<Arguments> testGet() {
+    private static Stream<Arguments> testGetNoOldClassLoader() {
         return Stream.of( //
                 Arguments.of(new String[0], new URL[0]), //
                 Arguments.of( //
@@ -101,6 +118,39 @@ class ClassLoaderProviderTest {
                         new URL[]{fileUrl("elem1"), fileUrl("elem2")}));
     }
 
+    @Test
+    void testGetOldClassLoaderWithSameElementsAsMavenBuild() {
+        // Arrange
+        mockClasspathElements("elem1");
+        final var oldClassLoader = provider.get();
+        // Act
+        classLoader = provider.get();
+        // Assert
+        assertThat(classLoader).isSameAs(oldClassLoader);
+        verifyLogAddingToClassLoader("elem1");
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    void testGetOldClassLoaderWithDifferentElementsAsMavenBuild() {
+        // Arrange
+        doCallRealMethod().when(closer).closeIfCloseable(any());
+        mockClasspathElements("elem1");
+        final var oldClassLoader = provider.get();
+        mockClasspathElements("elem1", "elem2");
+        // Act
+        classLoader = provider.get();
+        // Assert
+        assertThat(classLoader).isNotSameAs(oldClassLoader);
+        assertThat(classLoader).isNotNull().isInstanceOf(URLClassLoader.class);
+        assertThat(((URLClassLoader) classLoader).getURLs()).containsExactlyInAnyOrder(fileUrl("elem1"), fileUrl("elem2"));
+        verify(logger, times(2)).debug("Attempt to add elem1 to ClassLoader.");
+        verifyLogAddingToClassLoader("elem2");
+        verify(logger).debug("ClassLoader will be re-created as elements of underlying maven build have changed.");
+        verifyNoMoreInteractions(logger);
+        verify(closer).closeIfCloseable(oldClassLoader);
+    }
+
     @SneakyThrows
     private static URL fileUrl(final String file) {
         return new URL("file", "", -1, Paths.get(file).toAbsolutePath().toString());
@@ -109,5 +159,9 @@ class ClassLoaderProviderTest {
     @SneakyThrows
     private void mockClasspathElements(final String... elements) {
         doReturn(List.of(elements)).when(mavenBuild).getClasspathElements();
+    }
+
+    private void verifyLogAddingToClassLoader(final String... classpathElements) {
+        Arrays.stream(classpathElements).forEach(resource -> verify(logger).debug("Attempt to add " + resource + " to ClassLoader."));
     }
 }

--- a/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/CloserTest.java
+++ b/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/CloserTest.java
@@ -1,7 +1,6 @@
 package io.github.tobi.laa.reflective.fluent.builders.mojo;
 
 import lombok.SneakyThrows;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.codehaus.plexus.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +69,7 @@ class CloserTest {
         final ThrowingCallable close = () -> closer.closeIfCloseable(closeable);
         // Assert
         assertThatThrownBy(close) //
-                .isExactlyInstanceOf(MojoExecutionException.class)
+                .isExactlyInstanceOf(Closer.CloseException.class)
                 .hasMessageMatching("Error while attempting to close .+\\.")
                 .hasCause(cause);
     }

--- a/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/MavenBuildTest.java
+++ b/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/MavenBuildTest.java
@@ -1,5 +1,8 @@
 package io.github.tobi.laa.reflective.fluent.builders.mojo;
 
+import lombok.SneakyThrows;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
@@ -10,6 +13,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -17,6 +22,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -201,5 +208,78 @@ class MavenBuildTest {
         // Assert
         assertThat(actual).isSameAs(artifacts);
         verify(mavenProject).getArtifacts();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SneakyThrows
+    void testGetClasspathElementsDependencyResolutionRequiredException(final boolean testPhase) {
+        // Arrange
+        final var exception = new DependencyResolutionRequiredException(Mockito.mock(Artifact.class));
+        mockTestPhase(testPhase);
+        if (testPhase) {
+            doThrow(exception).when(mavenProject).getTestClasspathElements();
+        } else {
+            doThrow(exception).when(mavenProject).getCompileClasspathElements();
+        }
+        // Act
+        final ThrowingCallable getClasspathElements = () -> mavenBuild.getClasspathElements();
+        // Assert
+        assertThatThrownBy(getClasspathElements).isSameAs(exception);
+        if (testPhase) {
+            verify(mavenProject).getTestClasspathElements();
+        } else {
+            verify(mavenProject).getCompileClasspathElements();
+        }
+        verifyNoMoreInteractions(mavenProject);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @SneakyThrows
+    void testGetClasspathElements(final boolean testPhase, final String[] expected) {
+        // Arrange
+        mockTestPhase(testPhase);
+        if (testPhase) {
+            mockTestClasspathElements(expected);
+        } else {
+            mockCompileClasspathElements(expected);
+        }
+        // Act
+        final var actual = mavenBuild.getClasspathElements();
+        // Assert
+        assertThat(actual).containsExactlyInAnyOrder(expected);
+        if (testPhase) {
+            verify(mavenProject).getTestClasspathElements();
+        } else {
+            verify(mavenProject).getCompileClasspathElements();
+        }
+        verifyNoMoreInteractions(mavenProject);
+    }
+
+    private static Stream<Arguments> testGetClasspathElements() {
+        return Stream.of( //
+                Arguments.of(false, new String[0]), //
+                Arguments.of(true, new String[0]), //
+                Arguments.of(false, new String[]{"elem1"}),
+                Arguments.of(true, new String[]{"elem1", "elem2"}));
+    }
+
+    private void mockTestPhase(final boolean testPhase) {
+        if (testPhase) {
+            doReturn("generate-test-sources").when(mojoExecution).getLifecyclePhase();
+        } else {
+            doReturn("generate-sources").when(mojoExecution).getLifecyclePhase();
+        }
+    }
+
+    @SneakyThrows
+    private void mockTestClasspathElements(final String... elements) {
+        doReturn(List.of(elements)).when(mavenProject).getTestClasspathElements();
+    }
+
+    @SneakyThrows
+    private void mockCompileClasspathElements(final String... elements) {
+        doReturn(List.of(elements)).when(mavenProject).getCompileClasspathElements();
     }
 }


### PR DESCRIPTION
Fixes #136 
Fixes #122

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [x] Build pipeline passes.
- [x] Test coverage is 100%.