### PR TITLE
Feature/140 constructor visibility

### DIFF
--- a/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/generator/api/JavaFileGeneratorIT.java
+++ b/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/generator/api/JavaFileGeneratorIT.java
@@ -97,8 +97,12 @@ class JavaFileGeneratorIT {
                         "    this.objectToBuild = objectToBuild;\n" +
                         "  }\n" +
                         "\n" +
+                        "  protected ClassWithGenericsBuilder() {\n" +
+                        "    // noop\n" +
+                        "  }\n" +
+                        "\n" +
                         "  public static ClassWithGenericsBuilder newInstance() {\n" +
-                        "    return new ClassWithGenericsBuilder(null);\n" +
+                        "    return new ClassWithGenericsBuilder();\n" +
                         "  }\n" +
                         "\n" +
                         "  public static ClassWithGenericsBuilder thatModifies(final ClassWithGenerics objectToModify) {\n" +

--- a/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/generator/api/JavaFileGeneratorIT.java
+++ b/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/generator/api/JavaFileGeneratorIT.java
@@ -93,7 +93,7 @@ class JavaFileGeneratorIT {
                         "\n" +
                         "  private final FieldValue fieldValue = new FieldValue();\n" +
                         "\n" +
-                        "  private ClassWithGenericsBuilder(final ClassWithGenerics objectToBuild) {\n" +
+                        "  protected ClassWithGenericsBuilder(final ClassWithGenerics objectToBuild) {\n" +
                         "    this.objectToBuild = objectToBuild;\n" +
                         "  }\n" +
                         "\n" +

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorCodeGenerator.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorCodeGenerator.java
@@ -25,7 +25,7 @@ class ConstructorCodeGenerator implements MethodCodeGenerator {
     public Optional<MethodSpec> generate(final BuilderMetadata builderMetadata) {
         Objects.requireNonNull(builderMetadata);
         return Optional.of(MethodSpec.constructorBuilder()
-                .addModifiers(Modifier.PRIVATE)
+                .addModifiers(Modifier.PROTECTED)
                 .addParameter(builderMetadata.getBuiltType().getType(), OBJECT_TO_BUILD_FIELD_NAME, Modifier.FINAL)
                 .addStatement("this.$1L = $1L", OBJECT_TO_BUILD_FIELD_NAME)
                 .build());

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorWithObjectToBuildCodeGenerator.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorWithObjectToBuildCodeGenerator.java
@@ -14,12 +14,13 @@ import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderCon
 
 /**
  * <p>
- * Implementation of {@link MethodCodeGenerator} for generating the default constructor.
+ * Implementation of {@link MethodCodeGenerator} for generating a constructor that takes a pre-existing object to be
+ * modified.
  * </p>
  */
 @Named
 @Singleton
-class ConstructorCodeGenerator implements MethodCodeGenerator {
+class ConstructorWithObjectToBuildCodeGenerator implements MethodCodeGenerator {
 
     @Override
     public Optional<MethodSpec> generate(final BuilderMetadata builderMetadata) {

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/DefaultConstructorCodeGenerator.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/DefaultConstructorCodeGenerator.java
@@ -1,0 +1,34 @@
+package io.github.tobi.laa.reflective.fluent.builders.generator.impl;
+
+import com.squareup.javapoet.MethodSpec;
+import io.github.tobi.laa.reflective.fluent.builders.generator.api.MethodCodeGenerator;
+import io.github.tobi.laa.reflective.fluent.builders.model.BuilderMetadata;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.lang.model.element.Modifier;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * <p>
+ * Implementation of {@link MethodCodeGenerator} for generating a default (i.e. parameterless) constructor if possible.
+ * </p>
+ */
+@Named
+@Singleton
+class DefaultConstructorCodeGenerator implements MethodCodeGenerator {
+
+    @Override
+    public Optional<MethodSpec> generate(final BuilderMetadata builderMetadata) {
+        Objects.requireNonNull(builderMetadata);
+        if (builderMetadata.getBuiltType().isAccessibleNonArgsConstructor()) {
+            return Optional.of(MethodSpec.constructorBuilder() //
+                    .addModifiers(Modifier.PROTECTED) //
+                    .addComment("noop") //
+                    .build());
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/NewInstanceFactoryMethodCodeGenerator.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/NewInstanceFactoryMethodCodeGenerator.java
@@ -35,7 +35,7 @@ class NewInstanceFactoryMethodCodeGenerator implements MethodCodeGenerator {
             return Optional.of(MethodSpec.methodBuilder("newInstance")
                     .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                     .returns(builderClassName)
-                    .addStatement("return new $T(null)", builderClassName)
+                    .addStatement("return new $T()", builderClassName)
                     .build());
         } else {
             return Optional.empty();

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorCodeGeneratorTest.java
@@ -51,7 +51,7 @@ class ConstructorCodeGeneratorTest {
                                         .accessibleNonArgsConstructor(true) //
                                         .build()) //
                                 .build(), //
-                        "private Constructor(\n" +
+                        "protected Constructor(\n" +
                                 "    final io.github.tobi.laa.reflective.fluent.builders.test.models.simple.SimpleClass objectToBuild) {\n" +
                                 "  this.objectToBuild = objectToBuild;\n" +
                                 "}\n"),
@@ -64,7 +64,7 @@ class ConstructorCodeGeneratorTest {
                                         .accessibleNonArgsConstructor(false) //
                                         .build()) //
                                 .build(), //
-                        "private Constructor(\n" +
+                        "protected Constructor(\n" +
                                 "    final io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.ClassWithHierarchy objectToBuild) {\n" +
                                 "  this.objectToBuild = objectToBuild;\n" +
                                 "}\n"));

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorWithObjectToBuildCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorWithObjectToBuildCodeGeneratorTest.java
@@ -16,9 +16,9 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class ConstructorCodeGeneratorTest {
+class ConstructorWithObjectToBuildCodeGeneratorTest {
 
-    private final ConstructorCodeGenerator generator = new ConstructorCodeGenerator();
+    private final ConstructorWithObjectToBuildCodeGenerator generator = new ConstructorWithObjectToBuildCodeGenerator();
 
     @Test
     void testGenerateNull() {

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorWithObjectToBuildCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/ConstructorWithObjectToBuildCodeGeneratorTest.java
@@ -69,8 +69,4 @@ class ConstructorWithObjectToBuildCodeGeneratorTest {
                                 "  this.objectToBuild = objectToBuild;\n" +
                                 "}\n"));
     }
-
-    private static class MockType {
-        // no content
-    }
 }

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/DefaultConstructorCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/DefaultConstructorCodeGeneratorTest.java
@@ -1,0 +1,65 @@
+package io.github.tobi.laa.reflective.fluent.builders.generator.impl;
+
+import com.squareup.javapoet.MethodSpec;
+import io.github.tobi.laa.reflective.fluent.builders.model.BuilderMetadata;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.ClassWithHierarchy;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.simple.SimpleClass;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DefaultConstructorCodeGeneratorTest {
+
+    private final DefaultConstructorCodeGenerator generator = new DefaultConstructorCodeGenerator();
+
+    @Test
+    void testGenerateNull() {
+        // Arrange
+        final BuilderMetadata builderMetadata = null;
+        // Act
+        final Executable generate = () -> generator.generate(builderMetadata);
+        // Assert
+        assertThrows(NullPointerException.class, generate);
+    }
+
+    @Test
+    void testGenerateEmpty() {
+        // Arrange
+        final BuilderMetadata builderMetadata = BuilderMetadata.builder() //
+                .packageName("a.whole.different.pack") //
+                .name("AnotherBuilder") //
+                .builtType(BuilderMetadata.BuiltType.builder() //
+                        .type(ClassWithHierarchy.class) //
+                        .accessibleNonArgsConstructor(false) //
+                        .build()) //
+                .build();
+        // Act
+        final Optional<MethodSpec> actual = generator.generate(builderMetadata);
+        // Assert
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void testGeneratePresent() {
+        // Arrange
+        final BuilderMetadata builderMetadata = BuilderMetadata.builder() //
+                .packageName("io.github.tobi.laa.reflective.fluent.builders.test.models.simple") //
+                .name("SimpleClassBuilder") //
+                .builtType(BuilderMetadata.BuiltType.builder() //
+                        .type(SimpleClass.class) //
+                        .accessibleNonArgsConstructor(true) //
+                        .build()) //
+                .build();
+        // Act
+        final Optional<MethodSpec> actual = generator.generate(builderMetadata);
+        // Assert
+        assertThat(actual).isPresent();
+        assertThat(actual.get().toString()).isEqualToIgnoringNewLines("protected Constructor() {\n" +
+                "  // noop\n" +
+                "}\n");
+    }
+}

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/NewInstanceFactoryMethodCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/NewInstanceFactoryMethodCodeGeneratorTest.java
@@ -90,7 +90,7 @@ class NewInstanceFactoryMethodCodeGeneratorTest {
                         String.format(
                                 "public static %1$s newInstance(\n" +
                                         "    ) {\n" +
-                                        "  return new %1$s(null);\n" +
+                                        "  return new %1$s();\n" +
                                         "}\n", MockType.class.getName().replace('$', '.'))));
     }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/custom-hierarchy-collection-excludes/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/custom-hierarchy-collection-excludes/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
@@ -23,8 +23,12 @@ public class ClassWithHierarchyBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected ClassWithHierarchyBuilder() {
+    // noop
+  }
+
   public static ClassWithHierarchyBuilder newInstance() {
-    return new ClassWithHierarchyBuilder(null);
+    return new ClassWithHierarchyBuilder();
   }
 
   public static ClassWithHierarchyBuilder thatModifies(final ClassWithHierarchy objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/custom-hierarchy-collection-excludes/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/custom-hierarchy-collection-excludes/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
@@ -19,7 +19,7 @@ public class ClassWithHierarchyBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private ClassWithHierarchyBuilder(final ClassWithHierarchy objectToBuild) {
+  protected ClassWithHierarchyBuilder(final ClassWithHierarchy objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
@@ -24,8 +24,12 @@ public class BuiltClassAsMemberBuilder0 {
     this.objectToBuild = objectToBuild;
   }
 
+  protected BuiltClassAsMemberBuilder0() {
+    // noop
+  }
+
   public static BuiltClassAsMemberBuilder0 newInstance() {
-    return new BuiltClassAsMemberBuilder0(null);
+    return new BuiltClassAsMemberBuilder0();
   }
 
   public static BuiltClassAsMemberBuilder0 thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/BuiltClassAsMemberBuilder0.java
@@ -19,7 +19,7 @@ public class BuiltClassAsMemberBuilder0 {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private BuiltClassAsMemberBuilder0(
+  protected BuiltClassAsMemberBuilder0(
       final BuiltClassAsMemberBuilder.BuiltClassAsMember objectToBuild) {
     this.objectToBuild = objectToBuild;
   }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithBuilderExistingBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithBuilderExistingBuilder.java
@@ -19,7 +19,7 @@ public class ClassWithBuilderExistingBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private ClassWithBuilderExistingBuilder(final ClassWithBuilderExisting objectToBuild) {
+  protected ClassWithBuilderExistingBuilder(final ClassWithBuilderExisting objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
@@ -38,8 +38,12 @@ public class ClassWithCollectionsBuilder<T, U> {
     this.objectToBuild = objectToBuild;
   }
 
+  protected ClassWithCollectionsBuilder() {
+    // noop
+  }
+
   public static ClassWithCollectionsBuilder newInstance() {
-    return new ClassWithCollectionsBuilder(null);
+    return new ClassWithCollectionsBuilder();
   }
 
   public static ClassWithCollectionsBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
@@ -34,7 +34,7 @@ public class ClassWithCollectionsBuilder<T, U> {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private ClassWithCollectionsBuilder(final ClassWithCollections objectToBuild) {
+  protected ClassWithCollectionsBuilder(final ClassWithCollections objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithGenericsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithGenericsBuilder.java
@@ -22,7 +22,7 @@ public class ClassWithGenericsBuilder<T> {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private ClassWithGenericsBuilder(final ClassWithGenerics objectToBuild) {
+  protected ClassWithGenericsBuilder(final ClassWithGenerics objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithGenericsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithGenericsBuilder.java
@@ -26,8 +26,12 @@ public class ClassWithGenericsBuilder<T> {
     this.objectToBuild = objectToBuild;
   }
 
+  protected ClassWithGenericsBuilder() {
+    // noop
+  }
+
   public static ClassWithGenericsBuilder newInstance() {
-    return new ClassWithGenericsBuilder(null);
+    return new ClassWithGenericsBuilder();
   }
 
   public static ClassWithGenericsBuilder thatModifies(final ClassWithGenerics objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/GetAndAddBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/GetAndAddBuilder.java
@@ -26,8 +26,12 @@ public class GetAndAddBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected GetAndAddBuilder() {
+    // noop
+  }
+
   public static GetAndAddBuilder newInstance() {
-    return new GetAndAddBuilder(null);
+    return new GetAndAddBuilder();
   }
 
   public static GetAndAddBuilder thatModifies(final GetAndAdd objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/GetAndAddBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/GetAndAddBuilder.java
@@ -22,7 +22,7 @@ public class GetAndAddBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private GetAndAddBuilder(final GetAndAdd objectToBuild) {
+  protected GetAndAddBuilder(final GetAndAdd objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
@@ -23,8 +23,12 @@ public class ClassWithHierarchyBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected ClassWithHierarchyBuilder() {
+    // noop
+  }
+
   public static ClassWithHierarchyBuilder newInstance() {
-    return new ClassWithHierarchyBuilder(null);
+    return new ClassWithHierarchyBuilder();
   }
 
   public static ClassWithHierarchyBuilder thatModifies(final ClassWithHierarchy objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/ClassWithHierarchyBuilder.java
@@ -19,7 +19,7 @@ public class ClassWithHierarchyBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private ClassWithHierarchyBuilder(final ClassWithHierarchy objectToBuild) {
+  protected ClassWithHierarchyBuilder(final ClassWithHierarchy objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/FirstSuperClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/FirstSuperClassBuilder.java
@@ -19,7 +19,7 @@ public class FirstSuperClassBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private FirstSuperClassBuilder(final FirstSuperClass objectToBuild) {
+  protected FirstSuperClassBuilder(final FirstSuperClass objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/FirstSuperClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/FirstSuperClassBuilder.java
@@ -23,8 +23,12 @@ public class FirstSuperClassBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected FirstSuperClassBuilder() {
+    // noop
+  }
+
   public static FirstSuperClassBuilder newInstance() {
-    return new FirstSuperClassBuilder(null);
+    return new FirstSuperClassBuilder();
   }
 
   public static FirstSuperClassBuilder thatModifies(final FirstSuperClass objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericChildBuilder.java
@@ -25,7 +25,7 @@ public class GenericChildBuilder<S extends Number, T> {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private GenericChildBuilder(final GenericChild objectToBuild) {
+  protected GenericChildBuilder(final GenericChild objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericChildBuilder.java
@@ -29,8 +29,12 @@ public class GenericChildBuilder<S extends Number, T> {
     this.objectToBuild = objectToBuild;
   }
 
+  protected GenericChildBuilder() {
+    // noop
+  }
+
   public static GenericChildBuilder newInstance() {
-    return new GenericChildBuilder(null);
+    return new GenericChildBuilder();
   }
 
   public static GenericChildBuilder thatModifies(final GenericChild objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericGrandChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericGrandChildBuilder.java
@@ -30,8 +30,12 @@ public class GenericGrandChildBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected GenericGrandChildBuilder() {
+    // noop
+  }
+
   public static GenericGrandChildBuilder newInstance() {
-    return new GenericGrandChildBuilder(null);
+    return new GenericGrandChildBuilder();
   }
 
   public static GenericGrandChildBuilder thatModifies(final GenericGrandChild objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericGrandChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericGrandChildBuilder.java
@@ -26,7 +26,7 @@ public class GenericGrandChildBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private GenericGrandChildBuilder(final GenericGrandChild objectToBuild) {
+  protected GenericGrandChildBuilder(final GenericGrandChild objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericParentBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericParentBuilder.java
@@ -27,8 +27,12 @@ public class GenericParentBuilder<R, S, T> {
     this.objectToBuild = objectToBuild;
   }
 
+  protected GenericParentBuilder() {
+    // noop
+  }
+
   public static GenericParentBuilder newInstance() {
-    return new GenericParentBuilder(null);
+    return new GenericParentBuilder();
   }
 
   public static GenericParentBuilder thatModifies(final GenericParent objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericParentBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/generics/GenericParentBuilder.java
@@ -23,7 +23,7 @@ public class GenericParentBuilder<R, S, T> {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private GenericParentBuilder(final GenericParent objectToBuild) {
+  protected GenericParentBuilder(final GenericParent objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/second/SecondSuperClassInDifferentPackageBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/second/SecondSuperClassInDifferentPackageBuilder.java
@@ -24,8 +24,12 @@ public class SecondSuperClassInDifferentPackageBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected SecondSuperClassInDifferentPackageBuilder() {
+    // noop
+  }
+
   public static SecondSuperClassInDifferentPackageBuilder newInstance() {
-    return new SecondSuperClassInDifferentPackageBuilder(null);
+    return new SecondSuperClassInDifferentPackageBuilder();
   }
 
   public static SecondSuperClassInDifferentPackageBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/second/SecondSuperClassInDifferentPackageBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/second/SecondSuperClassInDifferentPackageBuilder.java
@@ -19,7 +19,7 @@ public class SecondSuperClassInDifferentPackageBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private SecondSuperClassInDifferentPackageBuilder(
+  protected SecondSuperClassInDifferentPackageBuilder(
       final SecondSuperClassInDifferentPackage objectToBuild) {
     this.objectToBuild = objectToBuild;
   }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
@@ -27,7 +27,7 @@ public class PersonBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private PersonBuilder(final Person objectToBuild) {
+  protected PersonBuilder(final Person objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
@@ -31,8 +31,12 @@ public class PersonBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected PersonBuilder() {
+    // noop
+  }
+
   public static PersonBuilder newInstance() {
-    return new PersonBuilder(null);
+    return new PersonBuilder();
   }
 
   public static PersonBuilder thatModifies(final Person objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PetBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PetBuilder.java
@@ -22,7 +22,7 @@ public class PetBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private PetBuilder(final Pet objectToBuild) {
+  protected PetBuilder(final Pet objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PetBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PetBuilder.java
@@ -26,8 +26,12 @@ public class PetBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected PetBuilder() {
+    // noop
+  }
+
   public static PetBuilder newInstance() {
-    return new PetBuilder(null);
+    return new PetBuilder();
   }
 
   public static PetBuilder thatModifies(final Pet objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/EntryBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/EntryBuilder.java
@@ -24,8 +24,12 @@ public class EntryBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected EntryBuilder() {
+    // noop
+  }
+
   public static EntryBuilder newInstance() {
-    return new EntryBuilder(null);
+    return new EntryBuilder();
   }
 
   public static EntryBuilder thatModifies(final PersonJaxb.Relations.Entry objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/EntryBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/EntryBuilder.java
@@ -20,7 +20,7 @@ public class EntryBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private EntryBuilder(final PersonJaxb.Relations.Entry objectToBuild) {
+  protected EntryBuilder(final PersonJaxb.Relations.Entry objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PersonJaxbBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PersonJaxbBuilder.java
@@ -27,8 +27,12 @@ public class PersonJaxbBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected PersonJaxbBuilder() {
+    // noop
+  }
+
   public static PersonJaxbBuilder newInstance() {
-    return new PersonJaxbBuilder(null);
+    return new PersonJaxbBuilder();
   }
 
   public static PersonJaxbBuilder thatModifies(final PersonJaxb objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PersonJaxbBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PersonJaxbBuilder.java
@@ -23,7 +23,7 @@ public class PersonJaxbBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private PersonJaxbBuilder(final PersonJaxb objectToBuild) {
+  protected PersonJaxbBuilder(final PersonJaxb objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PetJaxbBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PetJaxbBuilder.java
@@ -26,8 +26,12 @@ public class PetJaxbBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected PetJaxbBuilder() {
+    // noop
+  }
+
   public static PetJaxbBuilder newInstance() {
-    return new PetJaxbBuilder(null);
+    return new PetJaxbBuilder();
   }
 
   public static PetJaxbBuilder thatModifies(final PetJaxb objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PetJaxbBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/PetJaxbBuilder.java
@@ -22,7 +22,7 @@ public class PetJaxbBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private PetJaxbBuilder(final PetJaxb objectToBuild) {
+  protected PetJaxbBuilder(final PetJaxb objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/RelationsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/RelationsBuilder.java
@@ -21,7 +21,7 @@ public class RelationsBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private RelationsBuilder(final PersonJaxb.Relations objectToBuild) {
+  protected RelationsBuilder(final PersonJaxb.Relations objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/RelationsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/jaxb/RelationsBuilder.java
@@ -25,8 +25,12 @@ public class RelationsBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected RelationsBuilder() {
+    // noop
+  }
+
   public static RelationsBuilder newInstance() {
-    return new RelationsBuilder(null);
+    return new RelationsBuilder();
   }
 
   public static RelationsBuilder thatModifies(final PersonJaxb.Relations objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPackagePrivateLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPackagePrivateLevelOneBuilder.java
@@ -24,8 +24,12 @@ public class NestedPackagePrivateLevelOneBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected NestedPackagePrivateLevelOneBuilder() {
+    // noop
+  }
+
   public static NestedPackagePrivateLevelOneBuilder newInstance() {
-    return new NestedPackagePrivateLevelOneBuilder(null);
+    return new NestedPackagePrivateLevelOneBuilder();
   }
 
   public static NestedPackagePrivateLevelOneBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPackagePrivateLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPackagePrivateLevelOneBuilder.java
@@ -19,7 +19,7 @@ public class NestedPackagePrivateLevelOneBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private NestedPackagePrivateLevelOneBuilder(
+  protected NestedPackagePrivateLevelOneBuilder(
       final TopLevelClass.NestedPackagePrivateLevelOne objectToBuild) {
     this.objectToBuild = objectToBuild;
   }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedProtectedLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedProtectedLevelOneBuilder.java
@@ -24,8 +24,12 @@ public class NestedProtectedLevelOneBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected NestedProtectedLevelOneBuilder() {
+    // noop
+  }
+
   public static NestedProtectedLevelOneBuilder newInstance() {
-    return new NestedProtectedLevelOneBuilder(null);
+    return new NestedProtectedLevelOneBuilder();
   }
 
   public static NestedProtectedLevelOneBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedProtectedLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedProtectedLevelOneBuilder.java
@@ -19,7 +19,7 @@ public class NestedProtectedLevelOneBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private NestedProtectedLevelOneBuilder(
+  protected NestedProtectedLevelOneBuilder(
       final TopLevelClass.NestedProtectedLevelOne objectToBuild) {
     this.objectToBuild = objectToBuild;
   }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelOneBuilder.java
@@ -19,7 +19,7 @@ public class NestedPublicLevelOneBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private NestedPublicLevelOneBuilder(final TopLevelClass.NestedPublicLevelOne objectToBuild) {
+  protected NestedPublicLevelOneBuilder(final TopLevelClass.NestedPublicLevelOne objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelOneBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelOneBuilder.java
@@ -23,8 +23,12 @@ public class NestedPublicLevelOneBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected NestedPublicLevelOneBuilder() {
+    // noop
+  }
+
   public static NestedPublicLevelOneBuilder newInstance() {
-    return new NestedPublicLevelOneBuilder(null);
+    return new NestedPublicLevelOneBuilder();
   }
 
   public static NestedPublicLevelOneBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelThreeBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelThreeBuilder.java
@@ -24,8 +24,12 @@ public class NestedPublicLevelThreeBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected NestedPublicLevelThreeBuilder() {
+    // noop
+  }
+
   public static NestedPublicLevelThreeBuilder newInstance() {
-    return new NestedPublicLevelThreeBuilder(null);
+    return new NestedPublicLevelThreeBuilder();
   }
 
   public static NestedPublicLevelThreeBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelThreeBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelThreeBuilder.java
@@ -19,7 +19,7 @@ public class NestedPublicLevelThreeBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private NestedPublicLevelThreeBuilder(
+  protected NestedPublicLevelThreeBuilder(
       final TopLevelClass.NestedPublicLevelOne.NestedPublicLevelTwo.NestedPublicLevelThree objectToBuild) {
     this.objectToBuild = objectToBuild;
   }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelTwoBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelTwoBuilder.java
@@ -24,8 +24,12 @@ public class NestedPublicLevelTwoBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected NestedPublicLevelTwoBuilder() {
+    // noop
+  }
+
   public static NestedPublicLevelTwoBuilder newInstance() {
-    return new NestedPublicLevelTwoBuilder(null);
+    return new NestedPublicLevelTwoBuilder();
   }
 
   public static NestedPublicLevelTwoBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelTwoBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/NestedPublicLevelTwoBuilder.java
@@ -19,7 +19,7 @@ public class NestedPublicLevelTwoBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private NestedPublicLevelTwoBuilder(
+  protected NestedPublicLevelTwoBuilder(
       final TopLevelClass.NestedPublicLevelOne.NestedPublicLevelTwo objectToBuild) {
     this.objectToBuild = objectToBuild;
   }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/TopLevelClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/TopLevelClassBuilder.java
@@ -23,8 +23,12 @@ public class TopLevelClassBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected TopLevelClassBuilder() {
+    // noop
+  }
+
   public static TopLevelClassBuilder newInstance() {
-    return new TopLevelClassBuilder(null);
+    return new TopLevelClassBuilder();
   }
 
   public static TopLevelClassBuilder thatModifies(final TopLevelClass objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/TopLevelClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/nested/TopLevelClassBuilder.java
@@ -19,7 +19,7 @@ public class TopLevelClassBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private TopLevelClassBuilder(final TopLevelClass objectToBuild) {
+  protected TopLevelClassBuilder(final TopLevelClass objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
@@ -25,8 +25,12 @@ public class SimpleClassBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected SimpleClassBuilder() {
+    // noop
+  }
+
   public static SimpleClassBuilder newInstance() {
-    return new SimpleClassBuilder(null);
+    return new SimpleClassBuilder();
   }
 
   public static SimpleClassBuilder thatModifies(final SimpleClass objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
@@ -21,7 +21,7 @@ public class SimpleClassBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private SimpleClassBuilder(final SimpleClass objectToBuild) {
+  protected SimpleClassBuilder(final SimpleClass objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ChildBuilder.java
@@ -20,7 +20,7 @@ public class ChildBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private ChildBuilder(final Child objectToBuild) {
+  protected ChildBuilder(final Child objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ChildBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ChildBuilder.java
@@ -24,8 +24,12 @@ public class ChildBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected ChildBuilder() {
+    // noop
+  }
+
   public static ChildBuilder newInstance() {
-    return new ChildBuilder(null);
+    return new ChildBuilder();
   }
 
   public static ChildBuilder thatModifies(final Child objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ParentBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ParentBuilder.java
@@ -19,7 +19,7 @@ public class ParentBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private ParentBuilder(final Parent objectToBuild) {
+  protected ParentBuilder(final Parent objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ParentBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/hierarchy/ParentBuilder.java
@@ -23,8 +23,12 @@ public class ParentBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected ParentBuilder() {
+    // noop
+  }
+
   public static ParentBuilder newInstance() {
-    return new ParentBuilder(null);
+    return new ParentBuilder();
   }
 
   public static ParentBuilder thatModifies(final Parent objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
@@ -19,7 +19,7 @@ public class PackagePrivateBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private PackagePrivateBuilder(final PackagePrivate objectToBuild) {
+  protected PackagePrivateBuilder(final PackagePrivate objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateBuilder.java
@@ -23,8 +23,12 @@ public class PackagePrivateBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected PackagePrivateBuilder() {
+    // noop
+  }
+
   public static PackagePrivateBuilder newInstance() {
-    return new PackagePrivateBuilder(null);
+    return new PackagePrivateBuilder();
   }
 
   public static PackagePrivateBuilder thatModifies(final PackagePrivate objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
@@ -19,7 +19,7 @@ public class PackagePrivateConstructorBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private PackagePrivateConstructorBuilder(final PackagePrivateConstructor objectToBuild) {
+  protected PackagePrivateConstructorBuilder(final PackagePrivateConstructor objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructorBuilder.java
@@ -23,8 +23,12 @@ public class PackagePrivateConstructorBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected PackagePrivateConstructorBuilder() {
+    // noop
+  }
+
   public static PackagePrivateConstructorBuilder newInstance() {
-    return new PackagePrivateConstructorBuilder(null);
+    return new PackagePrivateConstructorBuilder();
   }
 
   public static PackagePrivateConstructorBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PrivateConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PrivateConstructorBuilder.java
@@ -19,7 +19,7 @@ public class PrivateConstructorBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private PrivateConstructorBuilder(final PrivateConstructor objectToBuild) {
+  protected PrivateConstructorBuilder(final PrivateConstructor objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
@@ -23,8 +23,12 @@ public class ProtectedConstructorBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected ProtectedConstructorBuilder() {
+    // noop
+  }
+
   public static ProtectedConstructorBuilder newInstance() {
-    return new ProtectedConstructorBuilder(null);
+    return new ProtectedConstructorBuilder();
   }
 
   public static ProtectedConstructorBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/ProtectedConstructorBuilder.java
@@ -19,7 +19,7 @@ public class ProtectedConstructorBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private ProtectedConstructorBuilder(final ProtectedConstructor objectToBuild) {
+  protected ProtectedConstructorBuilder(final ProtectedConstructor objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/SettersWithDifferentVisibilityBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/SettersWithDifferentVisibilityBuilder.java
@@ -24,8 +24,12 @@ public class SettersWithDifferentVisibilityBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected SettersWithDifferentVisibilityBuilder() {
+    // noop
+  }
+
   public static SettersWithDifferentVisibilityBuilder newInstance() {
-    return new SettersWithDifferentVisibilityBuilder(null);
+    return new SettersWithDifferentVisibilityBuilder();
   }
 
   public static SettersWithDifferentVisibilityBuilder thatModifies(

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/SettersWithDifferentVisibilityBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/SettersWithDifferentVisibilityBuilder.java
@@ -19,7 +19,7 @@ public class SettersWithDifferentVisibilityBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private SettersWithDifferentVisibilityBuilder(
+  protected SettersWithDifferentVisibilityBuilder(
       final SettersWithDifferentVisibility objectToBuild) {
     this.objectToBuild = objectToBuild;
   }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module1/io/github/tobi/laa/reflective/fluent/builders/test/models/DogBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module1/io/github/tobi/laa/reflective/fluent/builders/test/models/DogBuilder.java
@@ -20,7 +20,7 @@ public class DogBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private DogBuilder(final Dog objectToBuild) {
+  protected DogBuilder(final Dog objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module1/io/github/tobi/laa/reflective/fluent/builders/test/models/DogBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module1/io/github/tobi/laa/reflective/fluent/builders/test/models/DogBuilder.java
@@ -24,8 +24,12 @@ public class DogBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected DogBuilder() {
+    // noop
+  }
+
   public static DogBuilder newInstance() {
-    return new DogBuilder(null);
+    return new DogBuilder();
   }
 
   public static DogBuilder thatModifies(final Dog objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module2/io/github/tobi/laa/reflective/fluent/builders/test/models/CatBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module2/io/github/tobi/laa/reflective/fluent/builders/test/models/CatBuilder.java
@@ -24,8 +24,12 @@ public class CatBuilder {
     this.objectToBuild = objectToBuild;
   }
 
+  protected CatBuilder() {
+    // noop
+  }
+
   public static CatBuilder newInstance() {
-    return new CatBuilder(null);
+    return new CatBuilder();
   }
 
   public static CatBuilder thatModifies(final Cat objectToModify) {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module2/io/github/tobi/laa/reflective/fluent/builders/test/models/CatBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/multi-module-project/module2/io/github/tobi/laa/reflective/fluent/builders/test/models/CatBuilder.java
@@ -20,7 +20,7 @@ public class CatBuilder {
 
   private final FieldValue fieldValue = new FieldValue();
 
-  private CatBuilder(final Cat objectToBuild) {
+  protected CatBuilder(final Cat objectToBuild) {
     this.objectToBuild = objectToBuild;
   }
 


### PR DESCRIPTION
Fixes #140

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [x] Build pipeline passes.
- [x] Test coverage is 100%.
