### PR TITLE
Feature/147 filter out bridge methods

### DIFF
--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/AccessibilityService.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/AccessibilityService.java
@@ -1,0 +1,66 @@
+package io.github.tobi.laa.reflective.fluent.builders.service.api;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+/**
+ * <p>
+ * Provides service methods for checking whether a class, type, method or constructor is accessible from a given
+ * package.
+ * </p>
+ */
+public interface AccessibilityService {
+
+    /**
+     * <p>
+     * Checks whether {@code clazz} is accessible from the given {@code packageName}.
+     * </p>
+     *
+     * @param clazz       The class for which to check whether it is accessible from the given package. Must not be
+     *                    {@code null}.
+     * @param packageName The name of the package for which to check whether {@code clazz} is accessible from it. Must
+     *                    not be {@code null}.
+     * @return {@code true} if {@code clazz} is accessible from {@code packageName}, {@code false} otherwise.
+     */
+    boolean isAccessibleFrom(final Class<?> clazz, final String packageName);
+
+    /**
+     * <p>
+     * Checks whether {@code type} is accessible from the given {@code packageName}.
+     * </p>
+     *
+     * @param type        The type for which to check whether it is accessible from the given package. Must not be
+     *                    {@code null}.
+     * @param packageName The name of the package for which to check whether {@code type} is accessible from it. Must
+     *                    not be {@code null}.
+     * @return {@code true} if {@code type} is accessible from {@code packageName}, {@code false} otherwise.
+     */
+    boolean isAccessibleFrom(final Type type, final String packageName);
+
+    /**
+     * <p>
+     * Checks whether {@code method} is accessible from the given {@code packageName}.
+     * </p>
+     *
+     * @param method      The method for which to check whether it is accessible from the given package. Must not be
+     *                    {@code null}.
+     * @param packageName The name of the package for which to check whether {@code method} is accessible from it. Must
+     *                    not be {@code null}.
+     * @return {@code true} if {@code method} is accessible from {@code packageName}, {@code false} otherwise.
+     */
+    boolean isAccessibleFrom(final Method method, final String packageName);
+
+    /**
+     * <p>
+     * Checks whether {@code constructor} is accessible from the given {@code packageName}.
+     * </p>
+     *
+     * @param constructor The constructor for which to check whether it is accessible from the given package. Must not
+     *                    be {@code null}.
+     * @param packageName The name of the package for which to check whether {@code constructor} is accessible from it.
+     *                    Must not be {@code null}.
+     * @return {@code true} if {@code constructor} is accessible from {@code packageName}, {@code false} otherwise.
+     */
+    boolean isAccessibleFrom(final Constructor<?> constructor, final String packageName);
+}

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/BuilderPackageService.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/BuilderPackageService.java
@@ -1,0 +1,24 @@
+package io.github.tobi.laa.reflective.fluent.builders.service.api;
+
+import io.github.tobi.laa.reflective.fluent.builders.props.api.BuildersProperties;
+
+/**
+ * <p>
+ * Resolves the builder package for a given {@link Class}, that is the package which is configured to contain the
+ * builder for said class.
+ * </p>
+ *
+ * @see BuildersProperties#getBuilderPackage()
+ */
+public interface BuilderPackageService {
+
+    /**
+     * <p>
+     * Resolves the builder package for {@code clazz}, that is the package which is configured to contain its builder.
+     * </p>
+     *
+     * @param clazz The class for which the resolve the builder package. Must not be {@code null}.
+     * @return The package which is configured to contain the builder for {@code clazz}.
+     */
+    String resolveBuilderPackage(final Class<?> clazz);
+}

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/ClassService.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/api/ClassService.java
@@ -72,4 +72,14 @@ public interface ClassService {
      *                             load {@code className}.
      */
     Optional<Class<?>> loadClass(final String className);
+
+    /**
+     * <p>
+     * Checks whether the given class is abstract.
+     * </p>
+     *
+     * @param clazz The class for which to check whether it is an abstract class. Must not be {@code null}.
+     * @return {@code true} if {@code clazz} is abstract, {@code false} otherwise.
+     */
+    boolean isAbstract(final Class<?> clazz);
 }

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/AccessibilityServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/AccessibilityServiceImpl.java
@@ -1,0 +1,77 @@
+package io.github.tobi.laa.reflective.fluent.builders.service.impl;
+
+import io.github.tobi.laa.reflective.fluent.builders.model.Visibility;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.AccessibilityService;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.TypeService;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.VisibilityService;
+import lombok.RequiredArgsConstructor;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+import static io.github.tobi.laa.reflective.fluent.builders.model.Visibility.*;
+import static java.util.Arrays.stream;
+
+@Named
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+class AccessibilityServiceImpl implements AccessibilityService {
+
+    @lombok.NonNull
+    private final VisibilityService visibilityService;
+
+    @lombok.NonNull
+    private final TypeService typeService;
+
+    @lombok.NonNull
+    private final ClassService classService;
+
+    @Override
+    public boolean isAccessibleFrom(final Class<?> clazz, final String packageName) {
+        Objects.requireNonNull(clazz);
+        Objects.requireNonNull(packageName);
+        return isAccessible(clazz, clazz.getModifiers(), packageName);
+    }
+
+    @Override
+    public boolean isAccessibleFrom(final Type type, final String packageName) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(packageName);
+        return typeService.explodeType(type).stream().allMatch(clazz -> isAccessibleFrom(clazz, packageName));
+    }
+
+    @Override
+    public boolean isAccessibleFrom(final Method method, final String packageName) {
+        Objects.requireNonNull(method);
+        Objects.requireNonNull(packageName);
+        final var visibility = visibilityService.toVisibility(method.getModifiers());
+        return isAccessible(method.getDeclaringClass(), visibility, packageName) && //
+                isAccessibleFrom(method.getGenericReturnType(), packageName) && //
+                stream(method.getGenericParameterTypes()) //
+                        .allMatch(type -> isAccessibleFrom(type, packageName));
+    }
+
+    @Override
+    public boolean isAccessibleFrom(final Constructor<?> constructor, final String packageName) {
+        Objects.requireNonNull(constructor);
+        Objects.requireNonNull(packageName);
+        return isAccessible(constructor.getDeclaringClass(), constructor.getModifiers(), packageName);
+    }
+
+    private boolean isAccessible(final Class<?> clazz, final int modifiers, final String builderPackage) {
+        final var visibility = visibilityService.toVisibility(modifiers);
+        return isAccessible(clazz, visibility, builderPackage);
+    }
+
+    private boolean isAccessible(final Class<?> clazz, final Visibility visibility, final String builderPackage) {
+        return visibility == PUBLIC || //
+                visibility == PACKAGE_PRIVATE && !classService.isAbstract(clazz) && builderPackage.equals(clazz.getPackage().getName()) || //
+                visibility == PROTECTED && builderPackage.equals(clazz.getPackage().getName());
+    }
+}

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImpl.java
@@ -1,9 +1,7 @@
 package io.github.tobi.laa.reflective.fluent.builders.service.impl;
 
-import com.google.common.collect.ImmutableSortedSet;
 import io.github.tobi.laa.reflective.fluent.builders.model.BuilderMetadata;
 import io.github.tobi.laa.reflective.fluent.builders.model.Setter;
-import io.github.tobi.laa.reflective.fluent.builders.model.Visibility;
 import io.github.tobi.laa.reflective.fluent.builders.props.api.BuildersProperties;
 import io.github.tobi.laa.reflective.fluent.builders.service.api.*;
 import lombok.RequiredArgsConstructor;
@@ -13,14 +11,10 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Type;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderConstants.GENERATED_BUILDER_MARKER_FIELD_NAME;
-import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderConstants.PACKAGE_PLACEHOLDER;
-import static io.github.tobi.laa.reflective.fluent.builders.model.Visibility.*;
 import static java.lang.reflect.Modifier.isStatic;
 import static java.util.function.Predicate.not;
 
@@ -35,7 +29,7 @@ import static java.util.function.Predicate.not;
 class BuilderMetadataServiceImpl implements BuilderMetadataService {
 
     @lombok.NonNull
-    private final VisibilityService visibilityService;
+    private final AccessibilityService accessibilityService;
 
     @lombok.NonNull
     private final SetterService setterService;
@@ -44,7 +38,7 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
     private final ClassService classService;
 
     @lombok.NonNull
-    private final TypeService typeService;
+    private final BuilderPackageService builderPackageService;
 
     @lombok.NonNull
     private final BuildersProperties properties;
@@ -52,7 +46,7 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
     @Override
     public BuilderMetadata collectBuilderMetadata(final Class<?> clazz) {
         Objects.requireNonNull(clazz);
-        final String builderPackage = resolveBuilderPackage(clazz);
+        final String builderPackage = builderPackageService.resolveBuilderPackage(clazz);
         return BuilderMetadata.builder() //
                 .packageName(builderPackage) //
                 .name(builderClassName(clazz, builderPackage)) //
@@ -60,7 +54,7 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
                         .type(clazz) //
                         .location(classService.determineClassLocation(clazz).orElse(null)) //
                         .accessibleNonArgsConstructor(hasAccessibleNonArgsConstructor(clazz, builderPackage)) //
-                        .setters(gatherAndFilterAccessibleSettersAndAvoidNameCollisions(clazz, builderPackage))
+                        .setters(gatherSettersAndAvoidNameCollisions(clazz))
                         .build()) //
                 .build();
     }
@@ -89,33 +83,17 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
         }
     }
 
-    private String resolveBuilderPackage(final Class<?> clazz) {
-        return properties.getBuilderPackage().replace(PACKAGE_PLACEHOLDER, clazz.getPackageName());
-    }
-
     private boolean hasAccessibleNonArgsConstructor(final Class<?> clazz, final String builderPackage) {
         return Arrays //
                 .stream(clazz.getDeclaredConstructors()) //
-                .filter(constructor -> isAccessible(constructor, builderPackage)) //
+                .filter(constructor -> accessibilityService.isAccessibleFrom(constructor, builderPackage)) //
                 .mapToInt(Constructor::getParameterCount) //
                 .anyMatch(count -> count == 0);
     }
 
-    private boolean isAccessible(final Constructor<?> constructor, final String builderPackage) {
-        return isAccessible(constructor.getDeclaringClass(), constructor.getModifiers(), builderPackage);
-    }
-
-    private SortedSet<Setter> gatherAndFilterAccessibleSettersAndAvoidNameCollisions(final Class<?> clazz, final String builderPackage) {
-        final var setters = setterService.gatherAllSetters(clazz) //
-                .stream() //
-                .filter(setter -> isAccessibleSetter(setter, builderPackage)) //
-                .collect(ImmutableSortedSet.toImmutableSortedSet(Comparator.naturalOrder()));
+    private SortedSet<Setter> gatherSettersAndAvoidNameCollisions(final Class<?> clazz) {
+        final var setters = setterService.gatherAllSetters(clazz);
         return avoidNameCollisions(setters);
-    }
-
-    private boolean isAccessibleSetter(final Setter setter, final String builderPackage) {
-        return isAccessible(setter.getDeclaringClass(), setter.getVisibility(), builderPackage) && //
-                isAccessibleParamType(setter.getParamType(), builderPackage);
     }
 
     private SortedSet<Setter> avoidNameCollisions(final Set<Setter> setters) {
@@ -142,12 +120,12 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
         return classes //
                 .stream() //
                 .filter(not(Class::isInterface)) //
-                .filter(not(this::isAbstract)) //
                 .filter(not(Class::isAnonymousClass)) //
                 .filter(not(Class::isEnum)) //
                 .filter(not(Class::isPrimitive)) //
+                .filter(not(classService::isAbstract)) //
                 .filter(not(clazz -> clazz.isMemberClass() && !isStatic(clazz.getModifiers()))) //
-                .filter(clazz -> isAccessible(clazz, resolveBuilderPackage(clazz))) //
+                .filter(clazz -> accessibilityService.isAccessibleFrom(clazz, builderPackageService.resolveBuilderPackage(clazz))) //
                 .collect(Collectors.toSet());
     }
 
@@ -159,29 +137,6 @@ class BuilderMetadataServiceImpl implements BuilderMetadataService {
 
     private boolean exclude(final Class<?> clazz) {
         return properties.getExcludes().stream().anyMatch(p -> p.test(clazz));
-    }
-
-    private boolean isAbstract(final Class<?> clazz) {
-        return Modifier.isAbstract(clazz.getModifiers());
-    }
-
-    private boolean isAccessible(final Class<?> clazz, final String builderPackage) {
-        return isAccessible(clazz, clazz.getModifiers(), builderPackage);
-    }
-
-    private boolean isAccessibleParamType(final Type paramType, final String builderPackage) {
-        return typeService.explodeType(paramType).stream().allMatch(clazz -> isAccessible(clazz, builderPackage));
-    }
-
-    private boolean isAccessible(final Class<?> clazz, final int modifiers, final String builderPackage) {
-        final var visibility = visibilityService.toVisibility(modifiers);
-        return isAccessible(clazz, visibility, builderPackage);
-    }
-
-    private boolean isAccessible(final Class<?> clazz, final Visibility visibility, final String builderPackage) {
-        return visibility == PUBLIC || //
-                visibility == PACKAGE_PRIVATE && !isAbstract(clazz) && builderPackage.equals(clazz.getPackage().getName()) || //
-                visibility == PROTECTED && builderPackage.equals(clazz.getPackage().getName());
     }
 
     @Override

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderPackageServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderPackageServiceImpl.java
@@ -1,0 +1,32 @@
+package io.github.tobi.laa.reflective.fluent.builders.service.impl;
+
+import io.github.tobi.laa.reflective.fluent.builders.props.api.BuildersProperties;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.BuilderPackageService;
+import lombok.RequiredArgsConstructor;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Objects;
+
+import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderConstants.PACKAGE_PLACEHOLDER;
+
+/**
+ * <p>
+ * Standard implementation of {@link BuilderPackageService}.
+ * </p>
+ */
+@Named
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+class BuilderPackageServiceImpl implements BuilderPackageService {
+
+    @lombok.NonNull
+    private final BuildersProperties properties;
+
+    @Override
+    public String resolveBuilderPackage(final Class<?> clazz) {
+        Objects.requireNonNull(clazz);
+        return properties.getBuilderPackage().replace(PACKAGE_PLACEHOLDER, clazz.getPackageName());
+    }
+}

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImpl.java
@@ -12,6 +12,7 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.lang.reflect.Modifier;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -129,5 +130,11 @@ class ClassServiceImpl implements ClassService {
         } catch (final LinkageError | SecurityException e) {
             throw new ReflectionException("Error while attempting to load class " + className + '.', e);
         }
+    }
+
+    @Override
+    public boolean isAbstract(final Class<?> clazz) {
+        Objects.requireNonNull(clazz);
+        return Modifier.isAbstract(clazz.getModifiers());
     }
 }

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/AccessibilityServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/AccessibilityServiceImplTest.java
@@ -1,0 +1,262 @@
+package io.github.tobi.laa.reflective.fluent.builders.service.impl;
+
+import io.github.tobi.laa.reflective.fluent.builders.model.Visibility;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.TypeService;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.VisibilityService;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.visibility.PackagePrivateConstructor;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.visibility.SettersWithDifferentVisibility;
+import lombok.SneakyThrows;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static io.github.tobi.laa.reflective.fluent.builders.model.Visibility.*;
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccessibilityServiceImplTest {
+
+    @InjectMocks
+    private AccessibilityServiceImpl accessibilityService;
+
+    @Mock
+    private VisibilityService visibilityService;
+
+    @Mock
+    private TypeService typeService;
+
+    @Mock
+    private ClassService classService;
+
+    @ParameterizedTest
+    @MethodSource
+    void testIsClassAccessibleFromNull(final Class<?> clazz, final String packageName) {
+        // Act
+        final ThrowingCallable isAccessibleFrom = () -> accessibilityService.isAccessibleFrom(clazz, packageName);
+        // Assert
+        assertThatThrownBy(isAccessibleFrom).isExactlyInstanceOf(NullPointerException.class);
+        verifyNoInteractions(visibilityService, typeService, classService);
+    }
+
+    private static Stream<Arguments> testIsClassAccessibleFromNull() {
+        return Stream.of( //
+                Arguments.of(null, null), //
+                Arguments.of(String.class, null), //
+                Arguments.of(null, "a.package.name"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testIsClassAccessibleFrom(final Class<?> clazz, final String packageName, final Visibility visibility, final boolean isAbstract, final boolean expected) {
+        // Arrange
+        doReturn(visibility).when(visibilityService).toVisibility(anyInt());
+        lenient().doReturn(isAbstract).when(classService).isAbstract(clazz);
+        // Act
+        final boolean actual = accessibilityService.isAccessibleFrom(clazz, packageName);
+        // Assert
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> testIsClassAccessibleFrom() {
+        return Stream.of( //
+                Arguments.of(String.class, "java.lang", PRIVATE, false, false), //
+                Arguments.of(String.class, "java.lang", Visibility.PACKAGE_PRIVATE, false, true), //
+                Arguments.of(String.class, "java.lang", Visibility.PROTECTED, false, true), //
+                Arguments.of(String.class, "java.lang", PUBLIC, false, true), //
+                //
+                Arguments.of(String.class, "java.lang", PRIVATE, true, false), //
+                Arguments.of(String.class, "java.lang", Visibility.PACKAGE_PRIVATE, true, false), //
+                Arguments.of(String.class, "java.lang", Visibility.PROTECTED, true, true), //
+                Arguments.of(String.class, "java.lang", PUBLIC, true, true),
+                //
+                Arguments.of(String.class, "a.weird.package", PRIVATE, false, false), //
+                Arguments.of(String.class, "a.weird.package", Visibility.PACKAGE_PRIVATE, false, false), //
+                Arguments.of(String.class, "a.weird.package", Visibility.PROTECTED, false, false), //
+                Arguments.of(String.class, "a.weird.package", PUBLIC, false, true), //
+                //
+                Arguments.of(String.class, "a.weird.package", PRIVATE, true, false), //
+                Arguments.of(String.class, "a.weird.package", Visibility.PACKAGE_PRIVATE, true, false), //
+                Arguments.of(String.class, "a.weird.package", Visibility.PROTECTED, true, false), //
+                Arguments.of(String.class, "a.weird.package", PUBLIC, true, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testIsTypeAccessibleFromNull(final Type type, final String packageName) {
+        // Act
+        final ThrowingCallable isAccessibleFrom = () -> accessibilityService.isAccessibleFrom(type, packageName);
+        // Assert
+        assertThatThrownBy(isAccessibleFrom).isExactlyInstanceOf(NullPointerException.class);
+        verifyNoInteractions(visibilityService, typeService, classService);
+    }
+
+    private static Stream<Arguments> testIsTypeAccessibleFromNull() {
+        return Stream.of( //
+                Arguments.of(null, null), //
+                Arguments.of(String.class, null), //
+                Arguments.of(null, "a.package.name"));
+    }
+
+    @Test
+    @SneakyThrows
+    void testIsTypeAccessibleFromNotAllExplodedTypesAccessible() {
+        // Arrange
+        final Type type = Object.class;
+        final var packagePrivate = Class.forName("io.github.tobi.laa.reflective.fluent.builders.test.models.visibility.PackagePrivate");
+        final var packageName = "java.lang";
+        doReturn(Set.of(String.class, packagePrivate)).when(typeService).explodeType(type);
+        lenient().doReturn(PUBLIC).when(visibilityService).toVisibility(String.class.getModifiers());
+        doReturn(PACKAGE_PRIVATE).when(visibilityService).toVisibility(packagePrivate.getModifiers());
+        // Act
+        final boolean actual = accessibilityService.isAccessibleFrom(type, packageName);
+        // Assert
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    @SneakyThrows
+    void testIsTypeAccessibleFrom() {
+        // Arrange
+        final Type type = Object.class;
+        final var packagePrivate = Class.forName("io.github.tobi.laa.reflective.fluent.builders.test.models.visibility.PackagePrivate");
+        final var packageName = "java.lang";
+        doReturn(Set.of(String.class, packagePrivate)).when(typeService).explodeType(type);
+        doReturn(PUBLIC).when(visibilityService).toVisibility(String.class.getModifiers());
+        doReturn(PUBLIC).when(visibilityService).toVisibility(packagePrivate.getModifiers());
+        // Act
+        final boolean actual = accessibilityService.isAccessibleFrom(type, packageName);
+        // Assert
+        assertThat(actual).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testIsMethodAccessibleFromNull(final Method method, final String packageName) {
+        // Act
+        final ThrowingCallable isAccessibleFrom = () -> accessibilityService.isAccessibleFrom(method, packageName);
+        // Assert
+        assertThatThrownBy(isAccessibleFrom).isExactlyInstanceOf(NullPointerException.class);
+        verifyNoInteractions(visibilityService, typeService, classService);
+    }
+
+    @SneakyThrows
+    private static Stream<Arguments> testIsMethodAccessibleFromNull() {
+        return Stream.of( //
+                Arguments.of(null, null), //
+                Arguments.of(Object.class.getDeclaredMethod("toString"), null), //
+                Arguments.of(null, "a.package.name"));
+    }
+
+    @Test
+    @SneakyThrows
+    void testIsMethodAccessiblePrivateMethod() {
+        // Arrange
+        final Method method = SettersWithDifferentVisibility.class.getDeclaredMethod("setPrivateSetter", int.class);
+        final String packageName = "does.not.matter";
+        doReturn(PRIVATE).when(visibilityService).toVisibility(method.getModifiers());
+        // Act
+        final boolean actual = accessibilityService.isAccessibleFrom(method, packageName);
+        // Assert
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    @SneakyThrows
+    void testIsMethodAccessiblePublicMethodButInaccessibleReturnType() {
+        // Arrange
+        final Class<?> privateClass = Class.forName(PackagePrivateConstructor.class.getName() + "$PrivateClass");
+        final Method method = PackagePrivateConstructor.class.getDeclaredMethod("getPrivateClass");
+        final String packageName = "does.not.matter";
+        doReturn(PRIVATE).when(visibilityService).toVisibility(privateClass.getModifiers());
+        doReturn(PUBLIC).when(visibilityService).toVisibility(method.getModifiers());
+        doReturn(singleton(privateClass)).when(typeService).explodeType(privateClass);
+        // Act
+        final boolean actual = accessibilityService.isAccessibleFrom(method, packageName);
+        // Assert
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    @SneakyThrows
+    void testIsMethodAccessiblePublicMethodButInaccessibleParameter() {
+        // Arrange
+        final Class<?> privateClass = Class.forName(PackagePrivateConstructor.class.getName() + "$PrivateClass");
+        final Method method = PackagePrivateConstructor.class.getDeclaredMethod("setPrivateClass", privateClass);
+        final String packageName = "does.not.matter";
+        doReturn(PRIVATE).when(visibilityService).toVisibility(privateClass.getModifiers());
+        doReturn(PUBLIC).when(visibilityService).toVisibility(method.getModifiers());
+        doReturn(PUBLIC).when(visibilityService).toVisibility(void.class.getModifiers());
+        doReturn(singleton(void.class)).when(typeService).explodeType(void.class);
+        doReturn(singleton(privateClass)).when(typeService).explodeType(privateClass);
+        // Act
+        final boolean actual = accessibilityService.isAccessibleFrom(method, packageName);
+        // Assert
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    @SneakyThrows
+    void testIsMethodAccessible() {
+        // Arrange
+        final Method method = Object.class.getDeclaredMethod("toString");
+        final String packageName = "does.not.matter";
+        doReturn(PUBLIC).when(visibilityService).toVisibility(method.getModifiers());
+        // Act
+        final boolean actual = accessibilityService.isAccessibleFrom(method, packageName);
+        // Assert
+        assertThat(actual).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testIsConstructorAccessibleFromNull(final Constructor<?> constructor, final String packageName) {
+        // Act
+        final ThrowingCallable isAccessibleFrom = () -> accessibilityService.isAccessibleFrom(constructor, packageName);
+        // Assert
+        assertThatThrownBy(isAccessibleFrom).isExactlyInstanceOf(NullPointerException.class);
+        verifyNoInteractions(visibilityService, typeService, classService);
+    }
+
+    @SneakyThrows
+    private static Stream<Arguments> testIsConstructorAccessibleFromNull() {
+        return Stream.of( //
+                Arguments.of(null, null), //
+                Arguments.of(Object.class.getDeclaredConstructor(), null), //
+                Arguments.of(null, "a.package.name"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @SneakyThrows
+    void testIsConstructorAccessibleFrom(final Class<?> clazz, final String packageName, final Visibility visibility, final boolean isAbstract, final boolean expected) {
+        // Arrange
+        final Constructor<?> constructor = clazz.getDeclaredConstructor();
+        doReturn(visibility).when(visibilityService).toVisibility(anyInt());
+        lenient().doReturn(isAbstract).when(classService).isAbstract(clazz);
+        // Act
+        final boolean actual = accessibilityService.isAccessibleFrom(constructor, packageName);
+        // Assert
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> testIsConstructorAccessibleFrom() {
+        return testIsClassAccessibleFrom();
+    }
+}

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderMetadataServiceImplTest.java
@@ -6,10 +6,10 @@ import io.github.tobi.laa.reflective.fluent.builders.model.Setter;
 import io.github.tobi.laa.reflective.fluent.builders.model.SimpleSetter;
 import io.github.tobi.laa.reflective.fluent.builders.model.Visibility;
 import io.github.tobi.laa.reflective.fluent.builders.props.api.BuildersProperties;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.AccessibilityService;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.BuilderPackageService;
 import io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService;
 import io.github.tobi.laa.reflective.fluent.builders.service.api.SetterService;
-import io.github.tobi.laa.reflective.fluent.builders.service.api.TypeService;
-import io.github.tobi.laa.reflective.fluent.builders.service.api.VisibilityService;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.ClassWithCollections;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.ClassWithGenerics;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.Complex;
@@ -34,6 +34,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -54,7 +55,7 @@ class BuilderMetadataServiceImplTest {
     private BuilderMetadataServiceImpl builderService;
 
     @Mock
-    private VisibilityService visibilityService;
+    private AccessibilityService accessibilityService;
 
     @Mock
     private SetterService setterService;
@@ -63,7 +64,7 @@ class BuilderMetadataServiceImplTest {
     private ClassService classService;
 
     @Mock
-    private TypeService typeService;
+    private BuilderPackageService builderPackageService;
 
     @Mock
     private BuildersProperties properties;
@@ -79,17 +80,16 @@ class BuilderMetadataServiceImplTest {
     @ParameterizedTest
     @MethodSource
     void testCollectBuilderMetadata(final String builderPackage, final String builderSuffix,
-                                    final Visibility[] visibility, final SortedSet<Setter> setters,
+                                    final boolean accessibleConstructor, final SortedSet<Setter> setters,
                                     final Class<?> clazz, final Path location,
                                     final Optional<Class<?>>[] existingBuilderClasses, final BuilderMetadata expected) {
         // Arrange
-        when(properties.getBuilderPackage()).thenReturn(builderPackage);
+        doReturn(builderPackage).when(builderPackageService).resolveBuilderPackage(clazz);
         when(properties.getBuilderSuffix()).thenReturn(builderSuffix);
-        when(visibilityService.toVisibility(anyInt())).thenReturn(visibility[0], remove(visibility, 0));
+        doReturn(accessibleConstructor).when(accessibilityService).isAccessibleFrom(any(Constructor.class), any());
         when(setterService.gatherAllSetters(clazz)).thenReturn(setters);
         when(classService.determineClassLocation(clazz)).thenReturn(Optional.ofNullable(location));
         when(classService.loadClass(anyString())).thenReturn(existingBuilderClasses[0], remove(existingBuilderClasses, 0));
-        lenient().when(typeService.explodeType(any())).then(invocation -> singleton(invocation.getArguments()[0]));
         // Act
         final BuilderMetadata actual = builderService.collectBuilderMetadata(clazz);
         // Assert
@@ -111,10 +111,10 @@ class BuilderMetadataServiceImplTest {
         final var anotherPath = Paths.get("another/path");
         return Stream.of( //
                 Arguments.of( //
-                        "<PACKAGE_NAME>", //
+                        "io.github.tobi.laa.reflective.fluent.builders.test.models.simple", //
                         "Builder", //
-                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PUBLIC, Visibility.PUBLIC, Visibility.PUBLIC, Visibility.PUBLIC, Visibility.PUBLIC, Visibility.PUBLIC}, //
-                        ImmutableSortedSet.of(privateSetter, packagePrivateSetter, protectedSetter, protectedSetterFromAbstractClass, packagePrivateSetterFromAbstractClass, publicSetter, setterNameCollision1, setterNameCollision2), //
+                        true, //
+                        ImmutableSortedSet.of(packagePrivateSetter, protectedSetter, protectedSetterFromAbstractClass, publicSetter, setterNameCollision1, setterNameCollision2), //
                         SimpleClass.class, //
                         null, //
                         new Optional[]{Optional.empty()}, //
@@ -134,10 +134,10 @@ class BuilderMetadataServiceImplTest {
                                         .build()) //
                                 .build()), //
                 Arguments.of( //
-                        "<PACKAGE_NAME>.builder", //
+                        "io.github.tobi.laa.reflective.fluent.builders.test.models.complex.builder", //
                         "", //
-                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PUBLIC, Visibility.PUBLIC, Visibility.PUBLIC}, //
-                        ImmutableSortedSet.of(privateSetter, packagePrivateSetter, protectedSetter, publicSetter), //
+                        false, //
+                        ImmutableSortedSet.of(publicSetter), //
                         ClassWithCollections.class, //
                         aPath, //
                         new Optional[]{Optional.empty()}, //
@@ -152,18 +152,10 @@ class BuilderMetadataServiceImplTest {
                                         .build()) //
                                 .build()), //
                 Arguments.of( //
-                        "<PACKAGE_NAME>.builder", //
+                        "io.github.tobi.laa.reflective.fluent.builders.test.models.visibility.builder", //
                         "", //
-                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PACKAGE_PRIVATE, Visibility.PUBLIC, Visibility.PACKAGE_PRIVATE}, //
-                        ImmutableSortedSet.of(
-                                publicSetter, //
-                                SimpleSetter.builder() //
-                                        .methodName("setPackagePrivate") //
-                                        .paramName("packagePrivate") //
-                                        .paramType(packagePrivate) //
-                                        .visibility(Visibility.PUBLIC) //
-                                        .declaringClass(PackagePrivateConstructor.class) //
-                                        .build()), //
+                        false, //
+                        ImmutableSortedSet.of(publicSetter), //
                         PackagePrivateConstructor.class, //
                         anotherPath, //
                         new Optional[]{Optional.empty()}, //
@@ -178,9 +170,9 @@ class BuilderMetadataServiceImplTest {
                                         .build()) //
                                 .build()), //
                 Arguments.of( //
-                        "<PACKAGE_NAME>", //
+                        "io.github.tobi.laa.reflective.fluent.builders.test.models.visibility", //
                         "", //
-                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PACKAGE_PRIVATE, Visibility.PUBLIC, Visibility.PACKAGE_PRIVATE}, //
+                        true, //
                         ImmutableSortedSet.of(
                                 publicSetter, //
                                 SimpleSetter.builder() //
@@ -213,9 +205,8 @@ class BuilderMetadataServiceImplTest {
                 Arguments.of( //
                         "io.github.tobi.laa.reflective.fluent.builders.test.models.visibility", //
                         "", //
-                        new Visibility[]{Visibility.PACKAGE_PRIVATE, Visibility.PACKAGE_PRIVATE, Visibility.PRIVATE, Visibility.PACKAGE_PRIVATE}, //
+                        true, //
                         ImmutableSortedSet.of(
-                                publicSetter, //
                                 SimpleSetter.builder() //
                                         .methodName("setPackagePrivate") //
                                         .paramName("packagePrivate") //
@@ -245,8 +236,8 @@ class BuilderMetadataServiceImplTest {
                 Arguments.of( //
                         "the.builder.package", //
                         "MyBuilderSuffix", //
-                        new Visibility[]{Visibility.PUBLIC, Visibility.PUBLIC, Visibility.PUBLIC}, //
-                        ImmutableSortedSet.of(privateSetter, protectedSetter), //
+                        true, //
+                        Collections.emptySortedSet(), //
                         SimpleClassNoSetPrefix.class, //
                         aPath, //
                         new Optional[]{Optional.of(ClassWithoutMarkerField.class), Optional.empty()}, //
@@ -260,9 +251,9 @@ class BuilderMetadataServiceImplTest {
                                         .build()) //
                                 .build()), //
                 Arguments.of( //
-                        "builders.<PACKAGE_NAME>", //
+                        "builders.io.github.tobi.laa.reflective.fluent.builders.test.models.simple", //
                         "Builder", //
-                        new Visibility[]{Visibility.PUBLIC}, //
+                        false, //
                         Collections.emptySortedSet(), //
                         SimpleClassNoDefaultConstructor.class, //
                         anotherPath, //
@@ -287,47 +278,40 @@ class BuilderMetadataServiceImplTest {
         assertThrows(NullPointerException.class, filterOutNonBuildableClasses);
     }
 
-    @ParameterizedTest
-    @MethodSource
-    void testFilterOutNonBuildableClasses(final String builderPackage, final Visibility classVisibility,
-                                          final Set<Class<?>> classes, final Set<Class<?>> expected) {
+    @Test
+    void testFilterOutNonBuildableClassesNonConstructableClasses() {
         // Arrange
-        lenient().when(properties.getBuilderPackage()).thenReturn(builderPackage);
-        lenient().when(visibilityService.toVisibility(anyInt())).thenReturn(classVisibility);
+        final var classes = Set.of(Abstract.class, Annotation.class, Enum.class, Interface.class);
+        doReturn(true).when(classService).isAbstract(Abstract.class);
         // Act
         final Set<Class<?>> actual = builderService.filterOutNonBuildableClasses(classes);
         // Assert
-        assertEquals(expected, actual);
+        assertThat(actual).isEmpty();
     }
 
-    @SneakyThrows
-    private static Stream<Arguments> testFilterOutNonBuildableClasses() {
-        return Stream.of( //
-                Arguments.of( //
-                        "<PACKAGE_NAME>", //
-                        Visibility.PUBLIC, //
-                        Set.of(Abstract.class, Annotation.class, Enum.class, Interface.class),
-                        Collections.emptySet()), //
-                Arguments.of( //
-                        "<PACKAGE_NAME>", //
-                        Visibility.PACKAGE_PRIVATE, //
-                        Set.of(SimpleClass.class),
-                        Set.of(SimpleClass.class)), //
-                Arguments.of( //
-                        SimpleClass.class.getPackageName(), //
-                        Visibility.PACKAGE_PRIVATE, //
-                        Set.of(SimpleClass.class),
-                        Set.of(SimpleClass.class)), //
-                Arguments.of( //
-                        "<PACKAGE_NAME>.builder", //
-                        Visibility.PACKAGE_PRIVATE, //
-                        Set.of(SimpleClass.class),
-                        Collections.emptySet()),
-                Arguments.of( //
-                        "<PACKAGE_NAME>", //
-                        Visibility.PUBLIC, //
-                        Set.of(TopLevelClass.NestedPublicLevelOne.class, TopLevelClass.NestedNonStatic.class),
-                        Set.of(TopLevelClass.NestedPublicLevelOne.class)));
+    @Test
+    void testFilterOutNonBuildableClassesInaccessibleClass() {
+        // Arrange
+        final var classes = Set.of(SimpleClass.class, PackagePrivateConstructor.class);
+        doReturn(true).when(accessibilityService).isAccessibleFrom(eq(SimpleClass.class), any());
+        doReturn(false).when(accessibilityService).isAccessibleFrom(eq(PackagePrivateConstructor.class), any());
+        doReturn(false).when(classService).isAbstract(any());
+        // Act
+        final Set<Class<?>> actual = builderService.filterOutNonBuildableClasses(classes);
+        // Assert
+        assertThat(actual).containsExactly(SimpleClass.class);
+    }
+
+    @Test
+    void testFilterOutNonBuildableClassesNestedClasses() {
+        // Arrange
+        final var classes = Set.of(TopLevelClass.NestedPublicLevelOne.class, TopLevelClass.NestedNonStatic.class);
+        doReturn(true).when(accessibilityService).isAccessibleFrom(any(Class.class), any());
+        doReturn(false).when(classService).isAbstract(any());
+        // Act
+        final Set<Class<?>> actual = builderService.filterOutNonBuildableClasses(classes);
+        // Assert
+        assertThat(actual).containsExactly(TopLevelClass.NestedPublicLevelOne.class);
     }
 
     @Test

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderPackageServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/BuilderPackageServiceImplTest.java
@@ -1,0 +1,62 @@
+package io.github.tobi.laa.reflective.fluent.builders.service.impl;
+
+import io.github.tobi.laa.reflective.fluent.builders.props.api.BuildersProperties;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.ClassWithBuilderExisting;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.full.Person;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.simple.SimpleClass;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.stream.Stream;
+
+import static io.github.tobi.laa.reflective.fluent.builders.constants.BuilderConstants.PACKAGE_PLACEHOLDER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class BuilderPackageServiceImplTest {
+
+    @InjectMocks
+    private BuilderPackageServiceImpl service;
+
+    @Mock
+    private BuildersProperties properties;
+
+    @Test
+    void testResolveBuilderPackageNull() {
+        // Arrange
+        final Class<?> clazz = null;
+        // Act
+        final ThrowingCallable resolveBuilderPackage = () -> service.resolveBuilderPackage(clazz);
+        // Assert
+        assertThatThrownBy(resolveBuilderPackage).isExactlyInstanceOf(NullPointerException.class);
+        verifyNoInteractions(properties);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testResolveBuilderPackage(final Class<?> clazz, final String builderPackage, final String expected) {
+        // Arrange
+        doReturn(builderPackage).when(properties).getBuilderPackage();
+        // Act
+        final String actual = service.resolveBuilderPackage(clazz);
+        // Assert
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> testResolveBuilderPackage() {
+        return Stream.of( //
+                Arguments.of(SimpleClass.class, "a.fixed.package", "a.fixed.package"), //
+                Arguments.of(ClassWithBuilderExisting.class, PACKAGE_PLACEHOLDER, ClassWithBuilderExisting.class.getPackage().getName()), //
+                Arguments.of(Person.class, PACKAGE_PLACEHOLDER + ".builders", "io.github.tobi.laa.reflective.fluent.builders.test.models.full.builders"));
+    }
+}

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
@@ -303,6 +303,31 @@ class ClassServiceImplTest {
                 Arguments.of("io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService", ClassService.class));
     }
 
+    @Test
+    void testIsAbstractNull() {
+        // Arrange
+        final Class<?> clazz = null;
+        // Act
+        final ThrowingCallable isAbstract = () -> classServiceImpl.isAbstract(clazz);
+        // Assert
+        assertThatThrownBy(isAbstract).isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testIsAbstract(final Class<?> clazz, final boolean expected) {
+        // Act
+        final boolean actual = classServiceImpl.isAbstract(clazz);
+        // Assert
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> testIsAbstract() {
+        return Stream.of( //
+                Arguments.of(SimpleClass.class, false), //
+                Arguments.of(SimpleAbstractClass.class, true));
+    }
+
     @RequiredArgsConstructor
     private static class ThrowingClassLoader extends SecureClassLoader {
 

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/SetterServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/SetterServiceImplTest.java
@@ -2,6 +2,8 @@ package io.github.tobi.laa.reflective.fluent.builders.service.impl;
 
 import io.github.tobi.laa.reflective.fluent.builders.model.*;
 import io.github.tobi.laa.reflective.fluent.builders.props.api.BuildersProperties;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.AccessibilityService;
+import io.github.tobi.laa.reflective.fluent.builders.service.api.BuilderPackageService;
 import io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService;
 import io.github.tobi.laa.reflective.fluent.builders.service.api.VisibilityService;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.ClassWithCollections;
@@ -27,6 +29,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.*;
@@ -50,6 +53,12 @@ class SetterServiceImplTest {
 
     @Mock
     private ClassService classService;
+
+    @Mock
+    private AccessibilityService accessibilityService;
+
+    @Mock
+    private BuilderPackageService builderPackageService;
 
     @Mock
     private BuildersProperties properties;
@@ -127,6 +136,7 @@ class SetterServiceImplTest {
         }
         when(visibilityService.toVisibility(anyInt())).thenReturn(mockVisibility);
         when(classService.collectFullClassHierarchy(clazz)).thenReturn(List.of(clazz));
+        doReturn(true).when(accessibilityService).isAccessibleFrom(any(Method.class), any());
         // Act
         final Set<Setter> actual = setterService.gatherAllSetters(clazz);
         // Assert
@@ -196,6 +206,7 @@ class SetterServiceImplTest {
         when(properties.getSetterPrefix()).thenReturn("set");
         when(visibilityService.toVisibility(anyInt())).thenReturn(Visibility.PROTECTED);
         when(classService.collectFullClassHierarchy(any())).thenReturn(fullClassHierarchy);
+        doReturn(true).when(accessibilityService).isAccessibleFrom(any(Method.class), any());
         // Act
         final Set<Setter> actual = setterService.gatherAllSetters(clazz);
         // Assert

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/bridgemethod/BridgeMethodClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/bridgemethod/BridgeMethodClassBuilder.java
@@ -1,0 +1,65 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.bridgemethod;
+
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class BridgeMethodClassBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
+  @SuppressWarnings("unused")
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
+  private BridgeMethodClass objectToBuild;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  protected BridgeMethodClassBuilder(final BridgeMethodClass objectToBuild) {
+    this.objectToBuild = objectToBuild;
+  }
+
+  protected BridgeMethodClassBuilder() {
+    // noop
+  }
+
+  public static BridgeMethodClassBuilder newInstance() {
+    return new BridgeMethodClassBuilder();
+  }
+
+  public static BridgeMethodClassBuilder thatModifies(final BridgeMethodClass objectToModify) {
+    Objects.requireNonNull(objectToModify);
+    return new BridgeMethodClassBuilder(objectToModify);
+  }
+
+  public BridgeMethodClassBuilder something(final String something) {
+    this.fieldValue.something = something;
+    this.callSetterFor.something = true;
+    return this;
+  }
+
+  public BridgeMethodClass build() {
+    if (this.objectToBuild == null) {
+      this.objectToBuild = new BridgeMethodClass();
+    }
+    if (this.callSetterFor.something) {
+      this.objectToBuild.setSomething(this.fieldValue.something);
+    }
+    return this.objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean something;
+  }
+
+  private class FieldValue {
+    String something;
+  }
+}

--- a/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/bridgemethod/BridgeMethodAbstract.java
+++ b/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/bridgemethod/BridgeMethodAbstract.java
@@ -1,0 +1,11 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.bridgemethod;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+abstract class BridgeMethodAbstract<T> implements BridgeMethodInterface<T> {
+
+    private T something;
+}

--- a/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/bridgemethod/BridgeMethodClass.java
+++ b/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/bridgemethod/BridgeMethodClass.java
@@ -1,0 +1,5 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.bridgemethod;
+
+public class BridgeMethodClass extends BridgeMethodAbstract<String> {
+    // noop
+}

--- a/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/bridgemethod/BridgeMethodInterface.java
+++ b/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/hierarchy/bridgemethod/BridgeMethodInterface.java
@@ -1,0 +1,8 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.bridgemethod;
+
+public interface BridgeMethodInterface<T> {
+
+    T getSomething();
+
+    void setSomething(final T t);
+}

--- a/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructor.java
+++ b/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/visibility/PackagePrivateConstructor.java
@@ -1,10 +1,12 @@
 package io.github.tobi.laa.reflective.fluent.builders.test.models.visibility;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Setter
+@Getter
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class PackagePrivateConstructor {
 


### PR DESCRIPTION
Fixes #147 

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [x] Build pipeline passes.
- [x] Test coverage is 100%.
