### PR TITLE
Feature/149 setters for generic types that extending collections not generated correctly

### DIFF
--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/CollectionsApiInitializerCodeGenerator.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/CollectionsApiInitializerCodeGenerator.java
@@ -1,5 +1,6 @@
 package io.github.tobi.laa.reflective.fluent.builders.generator.impl;
 
+import com.google.common.reflect.TypeToken;
 import com.squareup.javapoet.CodeBlock;
 import com.sun.net.httpserver.Headers;
 import io.github.tobi.laa.reflective.fluent.builders.exception.CodeGenerationException;
@@ -14,6 +15,7 @@ import javax.print.attribute.standard.PrinterStateReasons;
 import javax.script.SimpleBindings;
 import javax.swing.*;
 import java.awt.*;
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.*;
@@ -76,14 +78,14 @@ class CollectionsApiInitializerCodeGenerator implements CollectionInitializerCod
     public boolean isApplicable(final CollectionSetter collectionSetter) {
         Objects.requireNonNull(collectionSetter);
         return SUPPORTED_COLLECTIONS.stream() //
-                .anyMatch(type -> collectionSetter.getParamType().isAssignableFrom(type));
+                .anyMatch(type -> getRawType(collectionSetter.getParamType()).isAssignableFrom(type));
     }
 
     @Override
     public CodeBlock generateCollectionInitializer(final CollectionSetter collectionSetter) {
         Objects.requireNonNull(collectionSetter);
         return SUPPORTED_COLLECTIONS.stream() //
-                .filter(type -> collectionSetter.getParamType().isAssignableFrom(type)) //
+                .filter(type -> getRawType(collectionSetter.getParamType()).isAssignableFrom(type)) //
                 .map(type -> CodeBlock.builder().add("new $T<>()", type).build()) //
                 .findFirst() //
                 .orElseThrow(() -> new CodeGenerationException("Generation of initializing code blocks for " + collectionSetter + " is not supported."));
@@ -93,16 +95,20 @@ class CollectionsApiInitializerCodeGenerator implements CollectionInitializerCod
     public boolean isApplicable(final MapSetter mapSetter) {
         Objects.requireNonNull(mapSetter);
         return SUPPORTED_MAPS.stream() //
-                .anyMatch(type -> mapSetter.getParamType().isAssignableFrom(type));
+                .anyMatch(type -> getRawType(mapSetter.getParamType()).isAssignableFrom(type));
     }
 
     @Override
     public CodeBlock generateMapInitializer(final MapSetter mapSetter) {
         Objects.requireNonNull(mapSetter);
         return SUPPORTED_MAPS.stream() //
-                .filter(type -> mapSetter.getParamType().isAssignableFrom(type)) //
+                .filter(type -> getRawType(mapSetter.getParamType()).isAssignableFrom(type)) //
                 .map(type -> CodeBlock.builder().add("new $T<>()", type).build()) //
                 .findFirst() //
                 .orElseThrow(() -> new CodeGenerationException("Generation of initializing code blocks for " + mapSetter + " is not supported."));
+    }
+
+    private Class<?> getRawType(final Type type) {
+        return TypeToken.of(type).getRawType();
     }
 }

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/TypeNameGeneratorImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/TypeNameGeneratorImpl.java
@@ -1,13 +1,18 @@
 package io.github.tobi.laa.reflective.fluent.builders.generator.impl;
 
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import io.github.tobi.laa.reflective.fluent.builders.generator.api.TypeNameGenerator;
 import io.github.tobi.laa.reflective.fluent.builders.model.Setter;
+import lombok.RequiredArgsConstructor;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -17,13 +22,21 @@ import java.util.Objects;
  */
 @Named
 @Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
 class TypeNameGeneratorImpl implements TypeNameGenerator {
 
     @SuppressWarnings("java:S3252") // false positive for static method call
     @Override
     public TypeName generateTypeNameForParam(final Setter setter) {
         Objects.requireNonNull(setter);
-        return TypeName.get(setter.getParamType());
+        if (setter.getParamType() instanceof ParameterizedType) {
+            final var parameterizedType = (ParameterizedType) setter.getParamType();
+            final var rawType = (Class<?>) parameterizedType.getRawType();
+            final Type[] typeArgs = Arrays.stream(parameterizedType.getActualTypeArguments()).map(this::wildcardToUpperBound).toArray(Type[]::new);
+            return ParameterizedTypeName.get(rawType, typeArgs);
+        } else {
+            return TypeName.get(setter.getParamType());
+        }
     }
 
     @Override

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/TypeNameGeneratorImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/TypeNameGeneratorImpl.java
@@ -1,10 +1,7 @@
 package io.github.tobi.laa.reflective.fluent.builders.generator.impl;
 
-import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import io.github.tobi.laa.reflective.fluent.builders.generator.api.TypeNameGenerator;
-import io.github.tobi.laa.reflective.fluent.builders.model.CollectionSetter;
-import io.github.tobi.laa.reflective.fluent.builders.model.MapSetter;
 import io.github.tobi.laa.reflective.fluent.builders.model.Setter;
 
 import javax.inject.Named;
@@ -26,20 +23,7 @@ class TypeNameGeneratorImpl implements TypeNameGenerator {
     @Override
     public TypeName generateTypeNameForParam(final Setter setter) {
         Objects.requireNonNull(setter);
-        if (setter instanceof CollectionSetter) {
-            final CollectionSetter collectionSetter = (CollectionSetter) setter;
-            return ParameterizedTypeName.get( //
-                    collectionSetter.getParamType(), //
-                    wildcardToUpperBound(collectionSetter.getParamTypeArg()));
-        } else if (setter instanceof MapSetter) {
-            final MapSetter mapSetter = (MapSetter) setter;
-            return ParameterizedTypeName.get( //
-                    mapSetter.getParamType(), //
-                    wildcardToUpperBound(mapSetter.getKeyType()), //
-                    wildcardToUpperBound(mapSetter.getValueType()));
-        } else {
-            return TypeName.get(setter.getParamType());
-        }
+        return TypeName.get(setter.getParamType());
     }
 
     @Override

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/CollectionSetter.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/CollectionSetter.java
@@ -19,7 +19,7 @@ import java.lang.reflect.Type;
 public class CollectionSetter extends AbstractSetter {
 
     @lombok.NonNull
-    private final Class<?> paramType;
+    private final Type paramType;
 
     /**
      * <p>

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/MapSetter.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/MapSetter.java
@@ -19,7 +19,7 @@ import java.lang.reflect.Type;
 public class MapSetter extends AbstractSetter {
 
     @lombok.NonNull
-    private final Class<?> paramType;
+    private final Type paramType;
 
     /**
      * <p>

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/SetterServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/SetterServiceImpl.java
@@ -84,8 +84,12 @@ class SetterServiceImpl implements SetterService {
 
     private boolean noCorrespondingSetter(final Method method, final Set<Setter> setters) {
         return setters.stream()
-                .noneMatch(setter -> setter.getParamType() == method.getReturnType() &&
+                .noneMatch(setter -> getRawType(setter.getParamType()) == method.getReturnType() &&
                         setter.getParamName().equals(dropGetterPrefix(method.getName())));
+    }
+
+    private Class<?> getRawType(final Type type) {
+        return TypeToken.of(type).getRawType();
     }
 
     private Setter toSetter(final Class<?> clazz, final Method method) {
@@ -101,20 +105,22 @@ class SetterServiceImpl implements SetterService {
                     .declaringClass(method.getDeclaringClass()) //
                     .build();
         } else if (Collection.class.isAssignableFrom(param.getType())) {
+            final var collectionType = resolveCollectionType(clazz, paramType);
             return CollectionSetter.builder() //
-                    .paramTypeArg(typeArg(paramType, 0)) //
+                    .paramTypeArg(typeArg(collectionType, 0)) //
                     .methodName(method.getName()) //
-                    .paramType(param.getType()) //
+                    .paramType(paramType) //
                     .paramName(dropSetterPrefix(method.getName())) //
                     .visibility(visibilityService.toVisibility(method.getModifiers())) //
                     .declaringClass(method.getDeclaringClass()) //
                     .build();
         } else if (Map.class.isAssignableFrom(param.getType())) {
+            final var mapType = resolveMapType(clazz, paramType);
             return MapSetter.builder() //
-                    .keyType(typeArg(paramType, 0)) //
-                    .valueType(typeArg(paramType, 1)) //
+                    .keyType(typeArg(mapType, 0)) //
+                    .valueType(typeArg(mapType, 1)) //
                     .methodName(method.getName()) //
-                    .paramType(param.getType()) //
+                    .paramType(paramType) //
                     .paramName(dropSetterPrefix(method.getName())) //
                     .visibility(visibilityService.toVisibility(method.getModifiers())) //
                     .declaringClass(method.getDeclaringClass()) //
@@ -132,14 +138,36 @@ class SetterServiceImpl implements SetterService {
 
     @SuppressWarnings("java:S3252")
     private CollectionGetAndAdder toGetAndAdder(final Class<?> clazz, final Method method) {
-        final var returnType = resolveType(clazz, method.getGenericReturnType());
-        return CollectionGetAndAdder.builder().paramTypeArg(typeArg(returnType, 0)) //
+        final var paramType = resolveType(clazz, method.getGenericReturnType());
+        final var collectionType = resolveCollectionType(clazz, paramType);
+        return CollectionGetAndAdder.builder() //
+                .paramTypeArg(typeArg(collectionType, 0)) //
                 .methodName(method.getName()) //
-                .paramType(method.getReturnType()) //
+                .paramType(paramType) //
                 .paramName(dropGetterPrefix(method.getName())) //
                 .visibility(visibilityService.toVisibility(method.getModifiers())) //
                 .declaringClass(method.getDeclaringClass()) //
                 .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Type resolveCollectionType(final Class<?> clazz, final Type collectionType) {
+        if (collectionType instanceof ParameterizedType) {
+            final TypeToken<? extends Collection<?>> typeToken = (TypeToken<? extends Collection<?>>) TypeToken.of(clazz).resolveType(collectionType);
+            return typeToken.getSupertype(Collection.class).getType();
+        } else {
+            return Collection.class;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Type resolveMapType(final Class<?> clazz, final Type mapType) {
+        if (mapType instanceof ParameterizedType) {
+            final TypeToken<? extends Map<?, ?>> typeToken = (TypeToken<? extends Map<?, ?>>) TypeToken.of(clazz).resolveType(mapType);
+            return typeToken.getSupertype(Map.class).getType();
+        } else {
+            return Map.class;
+        }
     }
 
     private Type typeArg(final Type type, final int num) {

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/CollectionsApiInitializerCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/CollectionsApiInitializerCodeGeneratorTest.java
@@ -82,7 +82,7 @@ class CollectionsApiInitializerCodeGeneratorTest {
                 .isInstanceOf(CodeGenerationException.class)
                 .message()
                 .matches("Generation of initializing code blocks for .+ is not supported.")
-                .contains(collectionSetter.getParamType().getName());
+                .contains(collectionSetter.getParamType().getTypeName());
     }
 
     private static Stream<CollectionSetter> testGenerateCollectionInitializerCodeGenerationException() {
@@ -195,7 +195,7 @@ class CollectionsApiInitializerCodeGeneratorTest {
                 .isInstanceOf(CodeGenerationException.class)
                 .message()
                 .matches("Generation of initializing code blocks for .+ is not supported.")
-                .contains(mapSetter.getParamType().getName());
+                .contains(mapSetter.getParamType().getTypeName());
     }
 
     private static Stream<MapSetter> testGenerateMapInitializerCodeGenerationException() {

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/EnumMapInitializerCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/EnumMapInitializerCodeGeneratorTest.java
@@ -88,7 +88,7 @@ class EnumMapInitializerCodeGeneratorTest {
                 .isInstanceOf(CodeGenerationException.class)
                 .message()
                 .matches("Generation of initializing code blocks for .+ is not supported.")
-                .contains(mapSetter.getParamType().getName());
+                .contains(mapSetter.getParamType().getTypeName());
     }
 
     private static Stream<MapSetter> testGenerateMapInitializerCodeGenerationException() {

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/EnumSetInitializerCodeGeneratorTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/EnumSetInitializerCodeGeneratorTest.java
@@ -87,7 +87,7 @@ class EnumSetInitializerCodeGeneratorTest {
                 .isInstanceOf(CodeGenerationException.class)
                 .message()
                 .matches("Generation of initializing code blocks for .+ is not supported.")
-                .contains(collectionSetter.getParamType().getName());
+                .contains(collectionSetter.getParamType().getTypeName());
     }
 
     private static Stream<CollectionSetter> testGenerateCollectionInitializerCodeGenerationException() {

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/TypeNameGeneratorImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/TypeNameGeneratorImplTest.java
@@ -60,7 +60,7 @@ class TypeNameGeneratorImplTest {
                         CollectionSetter.builder() //
                                 .methodName("setDeque") //
                                 .paramName("deque") //
-                                .paramType(Deque.class) //
+                                .paramType(TypeUtils.parameterize(Deque.class, Object.class)) //
                                 .paramTypeArg(TypeUtils.wildcardType() //
                                         .withUpperBounds(Object.class) //
                                         .build()) //
@@ -73,7 +73,7 @@ class TypeNameGeneratorImplTest {
                         CollectionSetter.builder() //
                                 .methodName("setList") //
                                 .paramName("list") //
-                                .paramType(List.class) //
+                                .paramType(TypeUtils.parameterize(List.class, Character.class)) //
                                 .paramTypeArg(Character.class) //
                                 .visibility(Visibility.PRIVATE) //
                                 .declaringClass(ClassWithCollections.class) //
@@ -85,6 +85,7 @@ class TypeNameGeneratorImplTest {
                                 .methodName("setList") //
                                 .paramName("list") //
                                 .paramType(List.class) //
+                                .paramType(TypeUtils.parameterize(List.class, TypeUtils.parameterize(Map.class, String.class, Object.class))) //
                                 .paramTypeArg(TypeUtils.parameterize(Map.class, String.class, Object.class)) //
                                 .visibility(Visibility.PRIVATE) //
                                 .declaringClass(ClassWithCollections.class) //
@@ -106,7 +107,7 @@ class TypeNameGeneratorImplTest {
                         MapSetter.builder() //
                                 .methodName("setMap") //
                                 .paramName("map") //
-                                .paramType(Map.class) //
+                                .paramType(TypeUtils.parameterize(Map.class, String.class, Object.class)) //
                                 .keyType(String.class) //
                                 .valueType(Object.class) //
                                 .visibility(Visibility.PRIVATE) //
@@ -118,7 +119,7 @@ class TypeNameGeneratorImplTest {
                         MapSetter.builder() //
                                 .methodName("setMap") //
                                 .paramName("map") //
-                                .paramType(SortedMap.class) //
+                                .paramType(TypeUtils.parameterize(SortedMap.class, String.class, Object.class)) //
                                 .keyType(String.class) //
                                 .valueType(TypeUtils.wildcardType() //
                                         .withUpperBounds(Object.class) //

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/SetterServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/SetterServiceImplTest.java
@@ -8,6 +8,8 @@ import io.github.tobi.laa.reflective.fluent.builders.service.api.ClassService;
 import io.github.tobi.laa.reflective.fluent.builders.service.api.VisibilityService;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.ClassWithCollections;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.GetAndAdd;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.ListWithTwoParams;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.MapWithThreeParams;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.*;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.generics.Generic;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.complex.hierarchy.generics.GenericChild;
@@ -18,6 +20,7 @@ import io.github.tobi.laa.reflective.fluent.builders.test.models.jaxb.PersonJaxb
 import io.github.tobi.laa.reflective.fluent.builders.test.models.jaxb.PetJaxb;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.simple.SimpleClass;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.simple.SimpleClassNoSetPrefix;
+import lombok.SneakyThrows;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -150,7 +153,9 @@ class SetterServiceImplTest {
         verify(visibilityService, times(expected.size())).toVisibility(anyInt());
     }
 
+    @SneakyThrows
     private static Stream<Arguments> testGatherAllSetters() {
+        final var setOfList = ClassWithCollections.class.getDeclaredField("set").getGenericType();
         return Stream.of( //
                 Arguments.of("set", null, false, SimpleClass.class, Visibility.PUBLIC, //
                         Set.of( //
@@ -164,16 +169,18 @@ class SetterServiceImplTest {
                                 SimpleSetter.builder().methodName("aString").paramName("aString").paramType(String.class).visibility(Visibility.PACKAGE_PRIVATE).declaringClass(SimpleClassNoSetPrefix.class).build())), //
                 Arguments.of("set", "get", false, ClassWithCollections.class, Visibility.PRIVATE, //
                         Set.of( //
-                                CollectionSetter.builder().methodName("setInts").paramName("ints").paramType(Collection.class).paramTypeArg(Integer.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
+                                CollectionSetter.builder().methodName("setInts").paramName("ints").paramType(parameterize(Collection.class, Integer.class)).paramTypeArg(Integer.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
                                 CollectionSetter.builder().methodName("setList").paramName("list").paramType(List.class).paramTypeArg(Object.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
-                                CollectionSetter.builder().methodName("setSet").paramName("set").paramType(Set.class).paramTypeArg(List.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
-                                CollectionSetter.builder().methodName("setDeque").paramName("deque").paramType(Deque.class).paramTypeArg(wildcardType().withUpperBounds(Object.class).build()).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
-                                CollectionSetter.builder().methodName("setSortedSetWild").paramName("sortedSetWild").paramType(SortedSet.class).paramTypeArg(wildcardType().build()).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
+                                CollectionSetter.builder().methodName("setSet").paramName("set").paramType(setOfList).paramTypeArg(List.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
+                                CollectionSetter.builder().methodName("setDeque").paramName("deque").paramType(parameterize(Deque.class, wildcardType().withUpperBounds(Object.class).build())).paramTypeArg(wildcardType().withUpperBounds(Object.class).build()).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
+                                CollectionSetter.builder().methodName("setSortedSetWild").paramName("sortedSetWild").paramType(parameterize(SortedSet.class, wildcardType().build())).paramTypeArg(wildcardType().build()).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
                                 ArraySetter.builder().methodName("setFloats").paramName("floats").paramType(float[].class).paramComponentType(float.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
-                                MapSetter.builder().methodName("setMap").paramName("map").paramType(Map.class).keyType(String.class).valueType(Object.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
-                                MapSetter.builder().methodName("setMapTU").paramName("mapTU").paramType(Map.class).keyType(typeVariableT()).valueType(typeVariableU()).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
-                                MapSetter.builder().methodName("setMapWildObj").paramName("mapWildObj").paramType(Map.class).keyType(wildcardType().build()).valueType(Object.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
-                                MapSetter.builder().methodName("setMapNoTypeArgs").paramName("mapNoTypeArgs").paramType(Map.class).keyType(Object.class).valueType(Object.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build())), //
+                                MapSetter.builder().methodName("setMap").paramName("map").paramType(parameterize(Map.class, String.class, Object.class)).keyType(String.class).valueType(Object.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
+                                MapSetter.builder().methodName("setMapTU").paramName("mapTU").paramType(parameterize(Map.class, typeVariableT(), typeVariableU())).keyType(typeVariableT()).valueType(typeVariableU()).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
+                                MapSetter.builder().methodName("setMapWildObj").paramName("mapWildObj").paramType(parameterize(Map.class, wildcardType().build(), Object.class)).keyType(wildcardType().build()).valueType(Object.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
+                                MapSetter.builder().methodName("setMapNoTypeArgs").paramName("mapNoTypeArgs").paramType(Map.class).keyType(Object.class).valueType(Object.class).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
+                                CollectionSetter.builder().methodName("setListWithTwoParams").paramName("listWithTwoParams").paramType(parameterize(ListWithTwoParams.class, String.class, Integer.class)).paramTypeArg(parameterize(Map.class, String.class, Integer.class)).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build(), //
+                                MapSetter.builder().methodName("setMapWithThreeParams").paramName("mapWithThreeParams").paramType(parameterize(MapWithThreeParams.class, String.class, Integer.class, Boolean.class)).keyType(String.class).valueType(parameterize(Map.class, Integer.class, Boolean.class)).visibility(Visibility.PRIVATE).declaringClass(ClassWithCollections.class).build())), //
                 Arguments.of("set", "get", false, PetJaxb.class, Visibility.PRIVATE, //
                         Set.of( //
                                 SimpleSetter.builder().methodName("setFullName").paramName("fullName").paramType(String.class).visibility(Visibility.PRIVATE).declaringClass(PetJaxb.class).build(), //
@@ -183,7 +190,7 @@ class SetterServiceImplTest {
                         Set.of( //
                                 SimpleSetter.builder().methodName("setFullName").paramName("fullName").paramType(String.class).visibility(Visibility.PRIVATE).declaringClass(PetJaxb.class).build(), //
                                 SimpleSetter.builder().methodName("setWeight").paramName("weight").paramType(float.class).visibility(Visibility.PRIVATE).declaringClass(PetJaxb.class).build(), //
-                                CollectionGetAndAdder.builder().methodName("getSiblings").paramName("siblings").paramType(List.class).paramTypeArg(PetJaxb.class).visibility(Visibility.PRIVATE).declaringClass(PetJaxb.class).build(), //
+                                CollectionGetAndAdder.builder().methodName("getSiblings").paramName("siblings").paramType(parameterize(List.class, PetJaxb.class)).paramTypeArg(PetJaxb.class).visibility(Visibility.PRIVATE).declaringClass(PetJaxb.class).build(), //
                                 SimpleSetter.builder().methodName("setOwner").paramName("owner").paramType(PersonJaxb.class).visibility(Visibility.PRIVATE).declaringClass(PetJaxb.class).build())),
                 Arguments.of("set", "myPrefix", true, PetJaxb.class, Visibility.PRIVATE, //
                         Set.of( //
@@ -192,10 +199,10 @@ class SetterServiceImplTest {
                                 SimpleSetter.builder().methodName("setOwner").paramName("owner").paramType(PersonJaxb.class).visibility(Visibility.PRIVATE).declaringClass(PetJaxb.class).build())), //
                 Arguments.of("set", "get", true, GetAndAdd.class, Visibility.PUBLIC, //
                         Set.of( //
-                                CollectionSetter.builder().methodName("setListGetterAndSetter").paramName("listGetterAndSetter").paramType(List.class).paramTypeArg(String.class).visibility(Visibility.PUBLIC).declaringClass(GetAndAdd.class).build(), //
-                                CollectionGetAndAdder.builder().methodName("getListNoSetter").paramName("listNoSetter").paramType(List.class).paramTypeArg(String.class).visibility(Visibility.PUBLIC).declaringClass(GetAndAdd.class).build(), //
-                                CollectionSetter.builder().methodName("setListNoGetter").paramName("listNoGetter").paramType(List.class).paramTypeArg(String.class).visibility(Visibility.PUBLIC).declaringClass(GetAndAdd.class).build(), //
-                                CollectionGetAndAdder.builder().methodName("getListSetterWrongType").paramName("listSetterWrongType").paramType(List.class).paramTypeArg(String.class).visibility(Visibility.PUBLIC).declaringClass(GetAndAdd.class).build(), //
+                                CollectionSetter.builder().methodName("setListGetterAndSetter").paramName("listGetterAndSetter").paramType(parameterize(List.class, String.class)).paramTypeArg(String.class).visibility(Visibility.PUBLIC).declaringClass(GetAndAdd.class).build(), //
+                                CollectionGetAndAdder.builder().methodName("getListNoSetter").paramName("listNoSetter").paramType(parameterize(List.class, String.class)).paramTypeArg(String.class).visibility(Visibility.PUBLIC).declaringClass(GetAndAdd.class).build(), //
+                                CollectionSetter.builder().methodName("setListNoGetter").paramName("listNoGetter").paramType(parameterize(List.class, String.class)).paramTypeArg(String.class).visibility(Visibility.PUBLIC).declaringClass(GetAndAdd.class).build(), //
+                                CollectionGetAndAdder.builder().methodName("getListSetterWrongType").paramName("listSetterWrongType").paramType(parameterize(List.class, String.class)).paramTypeArg(String.class).visibility(Visibility.PUBLIC).declaringClass(GetAndAdd.class).build(), //
                                 ArraySetter.builder().methodName("setListSetterWrongType").paramName("listSetterWrongType").paramType(String[].class).paramComponentType(String.class).visibility(Visibility.PUBLIC).declaringClass(GetAndAdd.class).build())));
     }
 
@@ -205,7 +212,10 @@ class SetterServiceImplTest {
         // Arrange
         when(properties.getSetterPrefix()).thenReturn("set");
         when(visibilityService.toVisibility(anyInt())).thenReturn(Visibility.PROTECTED);
-        when(classService.collectFullClassHierarchy(any())).thenReturn(fullClassHierarchy);
+        doReturn(fullClassHierarchy).when(classService).collectFullClassHierarchy(any());
+        lenient().doReturn(List.of(List.class)).when(classService).collectFullClassHierarchy(List.class);
+        lenient().doReturn(List.of(Map.class)).when(classService).collectFullClassHierarchy(Map.class);
+        lenient().doReturn(List.of(Set.class)).when(classService).collectFullClassHierarchy(Set.class);
         doReturn(true).when(accessibilityService).isAccessibleFrom(any(Method.class), any());
         // Act
         final Set<Setter> actual = setterService.gatherAllSetters(clazz);
@@ -237,16 +247,16 @@ class SetterServiceImplTest {
                         GenericChild.class,
                         List.of(GenericChild.class, GenericParent.class),
                         Set.of( //
-                                CollectionSetter.builder().methodName("setList").paramName("list").paramType(List.class).paramTypeArg(String.class).visibility(Visibility.PROTECTED).declaringClass(GenericChild.class).build(), //
-                                MapSetter.builder().methodName("setMap").paramName("map").paramType(Map.class).keyType(typeVariableS()).valueType(typeVariableT()).visibility(Visibility.PROTECTED).declaringClass(GenericChild.class).build(), //
+                                CollectionSetter.builder().methodName("setList").paramName("list").paramType(parameterize(List.class, String.class)).paramTypeArg(String.class).visibility(Visibility.PROTECTED).declaringClass(GenericChild.class).build(), //
+                                MapSetter.builder().methodName("setMap").paramName("map").paramType(parameterize(Map.class, typeVariableS(), typeVariableT())).keyType(typeVariableS()).valueType(typeVariableT()).visibility(Visibility.PROTECTED).declaringClass(GenericChild.class).build(), //
                                 SimpleSetter.builder().methodName("setGeneric").paramName("generic").paramType(parameterize(Generic.class, typeVariableT())).visibility(Visibility.PROTECTED).declaringClass(GenericChild.class).build(), //
                                 SimpleSetter.builder().methodName("setOtherGeneric").paramName("otherGeneric").paramType(parameterize(Generic.class, String.class)).visibility(Visibility.PROTECTED).declaringClass(GenericParent.class).build())), //
                 Arguments.of(
                         GenericGrandChild.class,
                         List.of(GenericGrandChild.class, GenericChild.class, GenericParent.class),
                         Set.of( //
-                                CollectionSetter.builder().methodName("setList").paramName("list").paramType(List.class).paramTypeArg(String.class).visibility(Visibility.PROTECTED).declaringClass(GenericChild.class).build(), //
-                                MapSetter.builder().methodName("setMap").paramName("map").paramType(Map.class).keyType(Long.class).valueType(Boolean.class).visibility(Visibility.PROTECTED).declaringClass(GenericGrandChild.class).build(), //
+                                CollectionSetter.builder().methodName("setList").paramName("list").paramType(parameterize(List.class, String.class)).paramTypeArg(String.class).visibility(Visibility.PROTECTED).declaringClass(GenericChild.class).build(), //
+                                MapSetter.builder().methodName("setMap").paramName("map").paramType(parameterize(Map.class, Long.class, Boolean.class)).keyType(Long.class).valueType(Boolean.class).visibility(Visibility.PROTECTED).declaringClass(GenericGrandChild.class).build(), //
                                 SimpleSetter.builder().methodName("setGeneric").paramName("generic").paramType(parameterize(Generic.class, Boolean.class)).visibility(Visibility.PROTECTED).declaringClass(GenericGrandChild.class).build(),
                                 SimpleSetter.builder().methodName("setOtherGeneric").paramName("otherGeneric").paramType(parameterize(Generic.class, String.class)).visibility(Visibility.PROTECTED).declaringClass(GenericParent.class).build()))); //
     }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
@@ -1,5 +1,6 @@
 package io.github.tobi.laa.reflective.fluent.builders.test.models.complex;
 
+import java.lang.Boolean;
 import java.lang.Float;
 import java.lang.Integer;
 import java.lang.Object;
@@ -94,7 +95,7 @@ public class ClassWithCollectionsBuilder<T, U> {
     return new MapMapWildObj();
   }
 
-  public ClassWithCollectionsBuilder deque(final Deque<Object> deque) {
+  public ClassWithCollectionsBuilder deque(final Deque<?> deque) {
     this.fieldValue.deque = deque;
     this.callSetterFor.deque = true;
     return this;
@@ -112,14 +113,14 @@ public class ClassWithCollectionsBuilder<T, U> {
     return this;
   }
 
-  public ClassWithCollectionsBuilder list(final List<Object> list) {
+  public ClassWithCollectionsBuilder list(final List list) {
     this.fieldValue.list = list;
     this.callSetterFor.list = true;
     return this;
   }
 
   public ClassWithCollectionsBuilder listWithTwoParams(
-      final ClassWithCollections.ListWithTwoParams<String, Integer> listWithTwoParams) {
+      final ListWithTwoParams<String, Integer> listWithTwoParams) {
     this.fieldValue.listWithTwoParams = listWithTwoParams;
     this.callSetterFor.listWithTwoParams = true;
     return this;
@@ -131,7 +132,7 @@ public class ClassWithCollectionsBuilder<T, U> {
     return this;
   }
 
-  public ClassWithCollectionsBuilder mapNoTypeArgs(final Map<Object, Object> mapNoTypeArgs) {
+  public ClassWithCollectionsBuilder mapNoTypeArgs(final Map mapNoTypeArgs) {
     this.fieldValue.mapNoTypeArgs = mapNoTypeArgs;
     this.callSetterFor.mapNoTypeArgs = true;
     return this;
@@ -143,14 +144,14 @@ public class ClassWithCollectionsBuilder<T, U> {
     return this;
   }
 
-  public ClassWithCollectionsBuilder mapWildObj(final Map<Object, Object> mapWildObj) {
+  public ClassWithCollectionsBuilder mapWildObj(final Map<?, Object> mapWildObj) {
     this.fieldValue.mapWildObj = mapWildObj;
     this.callSetterFor.mapWildObj = true;
     return this;
   }
 
   public ClassWithCollectionsBuilder mapWithThreeParams(
-      final ClassWithCollections.MapWithThreeParams<String, Integer, Boolean> mapWithThreeParams) {
+      final MapWithThreeParams<String, Integer, Boolean> mapWithThreeParams) {
     this.fieldValue.mapWithThreeParams = mapWithThreeParams;
     this.callSetterFor.mapWithThreeParams = true;
     return this;
@@ -162,7 +163,7 @@ public class ClassWithCollectionsBuilder<T, U> {
     return this;
   }
 
-  public ClassWithCollectionsBuilder sortedSetWild(final SortedSet<Object> sortedSetWild) {
+  public ClassWithCollectionsBuilder sortedSetWild(final SortedSet<?> sortedSetWild) {
     this.fieldValue.sortedSetWild = sortedSetWild;
     this.callSetterFor.sortedSetWild = true;
     return this;
@@ -238,29 +239,29 @@ public class ClassWithCollectionsBuilder<T, U> {
   }
 
   private class FieldValue {
-    Deque<Object> deque;
+    Deque<?> deque;
 
     float[] floats;
 
     Collection<Integer> ints;
 
-    List<Object> list;
+    List list;
 
-    ClassWithCollections.ListWithTwoParams<String, Integer> listWithTwoParams;
+    ListWithTwoParams<String, Integer> listWithTwoParams;
 
     Map<String, Object> map;
 
-    Map<Object, Object> mapNoTypeArgs;
+    Map mapNoTypeArgs;
 
     Map<T, U> mapTU;
 
-    Map<Object, Object> mapWildObj;
+    Map<?, Object> mapWildObj;
 
-    ClassWithCollections.MapWithThreeParams<String, Integer, Boolean> mapWithThreeParams;
+    MapWithThreeParams<String, Integer, Boolean> mapWithThreeParams;
 
     Set<List> set;
 
-    SortedSet<Object> sortedSetWild;
+    SortedSet<?> sortedSetWild;
   }
 
   public class ArrayFloats {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
@@ -118,6 +118,13 @@ public class ClassWithCollectionsBuilder<T, U> {
     return this;
   }
 
+  public ClassWithCollectionsBuilder listWithTwoParams(
+      final ClassWithCollections.ListWithTwoParams<String, Integer> listWithTwoParams) {
+    this.fieldValue.listWithTwoParams = listWithTwoParams;
+    this.callSetterFor.listWithTwoParams = true;
+    return this;
+  }
+
   public ClassWithCollectionsBuilder map(final Map<String, Object> map) {
     this.fieldValue.map = map;
     this.callSetterFor.map = true;
@@ -139,6 +146,13 @@ public class ClassWithCollectionsBuilder<T, U> {
   public ClassWithCollectionsBuilder mapWildObj(final Map<Object, Object> mapWildObj) {
     this.fieldValue.mapWildObj = mapWildObj;
     this.callSetterFor.mapWildObj = true;
+    return this;
+  }
+
+  public ClassWithCollectionsBuilder mapWithThreeParams(
+      final ClassWithCollections.MapWithThreeParams<String, Integer, Boolean> mapWithThreeParams) {
+    this.fieldValue.mapWithThreeParams = mapWithThreeParams;
+    this.callSetterFor.mapWithThreeParams = true;
     return this;
   }
 
@@ -170,6 +184,9 @@ public class ClassWithCollectionsBuilder<T, U> {
     if (this.callSetterFor.list) {
       this.objectToBuild.setList(this.fieldValue.list);
     }
+    if (this.callSetterFor.listWithTwoParams) {
+      this.objectToBuild.setListWithTwoParams(this.fieldValue.listWithTwoParams);
+    }
     if (this.callSetterFor.map) {
       this.objectToBuild.setMap(this.fieldValue.map);
     }
@@ -181,6 +198,9 @@ public class ClassWithCollectionsBuilder<T, U> {
     }
     if (this.callSetterFor.mapWildObj) {
       this.objectToBuild.setMapWildObj(this.fieldValue.mapWildObj);
+    }
+    if (this.callSetterFor.mapWithThreeParams) {
+      this.objectToBuild.setMapWithThreeParams(this.fieldValue.mapWithThreeParams);
     }
     if (this.callSetterFor.set) {
       this.objectToBuild.setSet(this.fieldValue.set);
@@ -200,6 +220,8 @@ public class ClassWithCollectionsBuilder<T, U> {
 
     boolean list;
 
+    boolean listWithTwoParams;
+
     boolean map;
 
     boolean mapNoTypeArgs;
@@ -207,6 +229,8 @@ public class ClassWithCollectionsBuilder<T, U> {
     boolean mapTU;
 
     boolean mapWildObj;
+
+    boolean mapWithThreeParams;
 
     boolean set;
 
@@ -222,6 +246,8 @@ public class ClassWithCollectionsBuilder<T, U> {
 
     List<Object> list;
 
+    ClassWithCollections.ListWithTwoParams<String, Integer> listWithTwoParams;
+
     Map<String, Object> map;
 
     Map<Object, Object> mapNoTypeArgs;
@@ -229,6 +255,8 @@ public class ClassWithCollectionsBuilder<T, U> {
     Map<T, U> mapTU;
 
     Map<Object, Object> mapWildObj;
+
+    ClassWithCollections.MapWithThreeParams<String, Integer, Boolean> mapWithThreeParams;
 
     Set<List> set;
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollectionsBuilder.java
@@ -95,7 +95,7 @@ public class ClassWithCollectionsBuilder<T, U> {
     return new MapMapWildObj();
   }
 
-  public ClassWithCollectionsBuilder deque(final Deque<?> deque) {
+  public ClassWithCollectionsBuilder deque(final Deque<Object> deque) {
     this.fieldValue.deque = deque;
     this.callSetterFor.deque = true;
     return this;
@@ -144,7 +144,7 @@ public class ClassWithCollectionsBuilder<T, U> {
     return this;
   }
 
-  public ClassWithCollectionsBuilder mapWildObj(final Map<?, Object> mapWildObj) {
+  public ClassWithCollectionsBuilder mapWildObj(final Map<Object, Object> mapWildObj) {
     this.fieldValue.mapWildObj = mapWildObj;
     this.callSetterFor.mapWildObj = true;
     return this;
@@ -163,7 +163,7 @@ public class ClassWithCollectionsBuilder<T, U> {
     return this;
   }
 
-  public ClassWithCollectionsBuilder sortedSetWild(final SortedSet<?> sortedSetWild) {
+  public ClassWithCollectionsBuilder sortedSetWild(final SortedSet<Object> sortedSetWild) {
     this.fieldValue.sortedSetWild = sortedSetWild;
     this.callSetterFor.sortedSetWild = true;
     return this;
@@ -239,7 +239,7 @@ public class ClassWithCollectionsBuilder<T, U> {
   }
 
   private class FieldValue {
-    Deque<?> deque;
+    Deque<Object> deque;
 
     float[] floats;
 
@@ -255,13 +255,13 @@ public class ClassWithCollectionsBuilder<T, U> {
 
     Map<T, U> mapTU;
 
-    Map<?, Object> mapWildObj;
+    Map<Object, Object> mapWildObj;
 
     MapWithThreeParams<String, Integer, Boolean> mapWithThreeParams;
 
     Set<List> set;
 
-    SortedSet<?> sortedSetWild;
+    SortedSet<Object> sortedSetWild;
   }
 
   public class ArrayFloats {

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/full/PersonBuilder.java
@@ -68,7 +68,7 @@ public class PersonBuilder {
     return this;
   }
 
-  public PersonBuilder attributes(final List<Object> attributes) {
+  public PersonBuilder attributes(final List attributes) {
     this.fieldValue.attributes = attributes;
     this.callSetterFor.attributes = true;
     return this;
@@ -151,7 +151,7 @@ public class PersonBuilder {
   private class FieldValue {
     int age;
 
-    List<Object> attributes;
+    List attributes;
 
     boolean married;
 

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/simple/SimpleClassBuilder.java
@@ -1,6 +1,7 @@
 package io.github.tobi.laa.reflective.fluent.builders.test.models.simple;
 
 import java.lang.Class;
+import java.lang.Object;
 import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Objects;
@@ -58,7 +59,7 @@ public class SimpleClassBuilder {
     return this;
   }
 
-  public SimpleClassBuilder setClass(final Class<?> setClass) {
+  public SimpleClassBuilder setClass(final Class<Object> setClass) {
     this.fieldValue.setClass = setClass;
     this.callSetterFor.setClass = true;
     return this;
@@ -100,6 +101,6 @@ public class SimpleClassBuilder {
 
     boolean booleanField;
 
-    Class<?> setClass;
+    Class<Object> setClass;
   }
 }

--- a/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollections.java
+++ b/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollections.java
@@ -29,11 +29,5 @@ public class ClassWithCollections<T, U> {
 
     private MapWithThreeParams<String, Integer, Boolean> mapWithThreeParams;
 
-    static class ListWithTwoParams<A, B> extends ArrayList<Map<A, B>> {
-        private static final long serialVersionUID = 155076095692605279L;
-    }
 
-    static class MapWithThreeParams<A, B, C> extends HashMap<A, Map<B, C>> {
-        private static final long serialVersionUID = 6511712322776760125L;
-    }
 }

--- a/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollections.java
+++ b/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ClassWithCollections.java
@@ -24,4 +24,16 @@ public class ClassWithCollections<T, U> {
     private Map<?, Object> mapWildObj;
 
     private Map mapNoTypeArgs;
+
+    private ListWithTwoParams<String, Integer> listWithTwoParams;
+
+    private MapWithThreeParams<String, Integer, Boolean> mapWithThreeParams;
+
+    static class ListWithTwoParams<A, B> extends ArrayList<Map<A, B>> {
+        private static final long serialVersionUID = 155076095692605279L;
+    }
+
+    static class MapWithThreeParams<A, B, C> extends HashMap<A, Map<B, C>> {
+        private static final long serialVersionUID = 6511712322776760125L;
+    }
 }

--- a/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ListWithTwoParams.java
+++ b/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/ListWithTwoParams.java
@@ -1,0 +1,8 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+public class ListWithTwoParams<A, B> extends ArrayList<Map<A, B>> {
+    private static final long serialVersionUID = 155076095692605279L;
+}

--- a/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/MapWithThreeParams.java
+++ b/reflective-fluent-builders-test-models/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/MapWithThreeParams.java
@@ -1,0 +1,8 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapWithThreeParams<A, B, C> extends HashMap<A, Map<B, C>> {
+    private static final long serialVersionUID = 6511712322776760125L;
+}


### PR DESCRIPTION
Fixes #149 

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [ ] Build pipeline passes.
- [ ] Test coverage is 100%.
