### PR TITLE
Feature/154 make default for getandadd true

### DIFF
--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/props/impl/StandardBuildersProperties.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/props/impl/StandardBuildersProperties.java
@@ -33,7 +33,7 @@ public class StandardBuildersProperties implements BuildersProperties {
     @lombok.NonNull
     private String getterPrefix = "get";
 
-    private boolean getAndAddEnabled = false;
+    private boolean getAndAddEnabled = true;
 
     @lombok.NonNull
     @ToString.Exclude

--- a/reflective-fluent-builders-maven-plugin/src/it/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT.java
@@ -138,7 +138,7 @@ class GenerateBuildersMojoIT {
                                     "builderSuffix=Builder, " +
                                     "setterPrefix=set, " +
                                     "getterPrefix=get, " +
-                                    "getAndAddEnabled=false, " +
+                                    "getAndAddEnabled=true, " +
                                     "hierarchyCollection=MojoParams.HierarchyCollection(excludes=null), " +
                                     "includes=[Include(super=AbstractIncludeExclude(packageName=io.github.tobi.laa.reflective.fluent.builders.test.models.simple, className=null))], " +
                                     "excludes=null, " +

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/WithDefaultConfig/packageComplex/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/WithDefaultConfig/packageComplex/pom.xml
@@ -37,7 +37,6 @@
                             </packageName>
                         </include>
                     </includes>
-                    <getAndAddEnabled>true</getAndAddEnabled>
                 </configuration>
             </plugin>
         </plugins>

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/WithDefaultConfig/packageJaxb/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/WithDefaultConfig/packageJaxb/pom.xml
@@ -37,7 +37,6 @@
                             </packageName>
                         </include>
                     </includes>
-                    <getAndAddEnabled>true</getAndAddEnabled>
                 </configuration>
             </plugin>
         </plugins>

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuilders/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateExpectedBuilders/generateExpectedBuilders/pom.xml
@@ -39,7 +39,6 @@
                             <target>${project.basedir}/${it.resources.directory}/expected-builders/default-config
                             </target>
                             <addCompileSourceRoot>false</addCompileSourceRoot>
-                            <getAndAddEnabled>true</getAndAddEnabled>
                         </configuration>
                     </execution>
                     <execution>

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
@@ -297,7 +297,7 @@ public class GenerateBuildersMojo extends AbstractMojo {
      * @param getAndAddEnabled Whether to support using a get-and-add paradigm in generated builders.
      * @since 1.0.0
      */
-    @Parameter(name = "getAndAddEnabled", defaultValue = "false")
+    @Parameter(name = "getAndAddEnabled", defaultValue = "true")
     @SuppressWarnings("unused")
     public void setGetAndAddEnabled(final boolean getAndAddEnabled) {
         params.setGetAndAddEnabled(getAndAddEnabled);

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
  * cases where it is not possible (or very hard) to change the sources of said classes to generate builders directly.
  * </p>
  */
-@Mojo(name = "generate-builders", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(name = "generate-builders", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.TEST)
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class GenerateBuildersMojo extends AbstractMojo {
 


### PR DESCRIPTION
Fixes #154
Fixes #153 

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests, integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [x] Build pipeline passes.
- [x] Test coverage is 100%.
