### PR TITLE
Fix determination of deltas for non-project files

### DIFF
--- a/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/service/api/AccessibilityServiceIT.java
+++ b/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/service/api/AccessibilityServiceIT.java
@@ -206,6 +206,10 @@ class AccessibilityServiceIT {
     }
 
     private static Stream<Arguments> testIsConstructorAccessibleFrom() {
-        return testIsClassAccessibleFrom();
+        return Stream.concat(
+                testIsClassAccessibleFrom(),
+                Stream.of( //
+                        Arguments.of(ProtectedConstructor.class, "a.weird.package", false), //
+                        Arguments.of(ProtectedConstructor.class, ProtectedConstructor.class.getPackageName(), true)));
     }
 }

--- a/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/service/api/BuilderMetadataServiceIT.java
+++ b/reflective-fluent-builders-generator/src/it/java/io/github/tobi/laa/reflective/fluent/builders/service/api/BuilderMetadataServiceIT.java
@@ -251,8 +251,56 @@ class BuilderMetadataServiceIT {
                                         .location(classLocation(SimpleClassNoDefaultConstructor.class)) //
                                         .accessibleNonArgsConstructor(false) //
                                         .build()) //
-                                .build()) //
-        );
+                                .build()), //
+                Arguments.of( //
+                        BuilderConstants.PACKAGE_PLACEHOLDER, //
+                        "Builder", //
+                        "set", //
+                        classInfo.get(NameCollisions.class), //
+                        BuilderMetadata.builder() //
+                                .packageName(NameCollisions.class.getPackageName()) //
+                                .name("NameCollisionsBuilder") //
+                                .builtType(BuilderMetadata.BuiltType.builder() //
+                                        .type(classInfo.get(NameCollisions.class.getName())) //
+                                        .location(classLocation(NameCollisions.class)) //
+                                        .accessibleNonArgsConstructor(true) //
+                                        .setter(SimpleSetter.builder() //
+                                                .methodName("setField") //
+                                                .paramName("field") //
+                                                .paramType(int.class) //
+                                                .visibility(PUBLIC) //
+                                                .declaringClass(NameCollisions.class) //
+                                                .build()) //
+                                        .setter(SimpleSetter.builder() //
+                                                .methodName("setField") //
+                                                .paramName("field0") //
+                                                .paramType(String.class) //
+                                                .visibility(PUBLIC) //
+                                                .declaringClass(NameCollisions.class) //
+                                                .build()) //
+                                        .setter(SimpleSetter.builder() //
+                                                .methodName("setAnotherField") //
+                                                .paramName("anotherField") //
+                                                .paramType(boolean.class) //
+                                                .visibility(PUBLIC) //
+                                                .declaringClass(NameCollisions.class) //
+                                                .build()) //
+                                        .setter(SimpleSetter.builder() //
+                                                .methodName("setAnotherField") //
+                                                .paramName("anotherField0") //
+                                                .paramType(int.class) //
+                                                .visibility(PUBLIC) //
+                                                .declaringClass(NameCollisions.class) //
+                                                .build()) //
+                                        .setter(SimpleSetter.builder() //
+                                                .methodName("setAnotherField") //
+                                                .paramName("anotherField1") //
+                                                .paramType(String.class) //
+                                                .visibility(PUBLIC) //
+                                                .declaringClass(NameCollisions.class) //
+                                                .build()) //
+                                        .build()) //
+                                .build()));
     }
 
     private static Path classLocation(final Class<?> clazz) {

--- a/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
+++ b/reflective-fluent-builders-generator/src/test/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/ClassServiceImplTest.java
@@ -1,0 +1,46 @@
+package io.github.tobi.laa.reflective.fluent.builders.service.impl;
+
+import io.github.tobi.laa.reflective.fluent.builders.props.api.BuildersProperties;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.CodeSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClassServiceImplTest {
+
+    private ClassServiceImpl classServiceImpl;
+
+    @Mock
+    private BuildersProperties properties;
+
+    @BeforeEach
+    void init() {
+        classServiceImpl = new ClassServiceImpl(properties, ClassLoader::getSystemClassLoader);
+    }
+
+    @Test
+    @SneakyThrows
+    void testGetLocationAsPathURISyntaxException() {
+        // Arrange
+        final var codeSource = Mockito.mock(CodeSource.class);
+        final var url = Mockito.mock(URL.class);
+        when(codeSource.getLocation()).thenReturn(url);
+        when(url.toURI()).thenThrow(new URISyntaxException("mock", "Thrown in unit test."));
+        // Act
+        final Executable getLocationAsPath = () -> classServiceImpl.getLocationAsPath(codeSource);
+        // Assert
+        assertThrows(URISyntaxException.class, getLocationAsPath);
+    }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/NameCollisionsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/NameCollisionsBuilder.java
@@ -1,0 +1,111 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex;
+
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class NameCollisionsBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
+  @SuppressWarnings("unused")
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
+  private Supplier<NameCollisions> objectSupplier;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  protected NameCollisionsBuilder(final Supplier<NameCollisions> objectSupplier) {
+    this.objectSupplier = Objects.requireNonNull(objectSupplier);
+  }
+
+  public static NameCollisionsBuilder newInstance() {
+    return new NameCollisionsBuilder(NameCollisions::new);
+  }
+
+  public static NameCollisionsBuilder withSupplier(final Supplier<NameCollisions> supplier) {
+    return new NameCollisionsBuilder(supplier);
+  }
+
+  public NameCollisionsBuilder anotherField(final boolean anotherField) {
+    this.fieldValue.anotherField = anotherField;
+    this.callSetterFor.anotherField = true;
+    return this;
+  }
+
+  public NameCollisionsBuilder anotherField(final int anotherField0) {
+    this.fieldValue.anotherField0 = anotherField0;
+    this.callSetterFor.anotherField0 = true;
+    return this;
+  }
+
+  public NameCollisionsBuilder anotherField(final String anotherField1) {
+    this.fieldValue.anotherField1 = anotherField1;
+    this.callSetterFor.anotherField1 = true;
+    return this;
+  }
+
+  public NameCollisionsBuilder field(final int field) {
+    this.fieldValue.field = field;
+    this.callSetterFor.field = true;
+    return this;
+  }
+
+  public NameCollisionsBuilder field(final String field0) {
+    this.fieldValue.field0 = field0;
+    this.callSetterFor.field0 = true;
+    return this;
+  }
+
+  public NameCollisions build() {
+    final NameCollisions objectToBuild = objectSupplier.get();
+    if (this.callSetterFor.anotherField) {
+      objectToBuild.setAnotherField(this.fieldValue.anotherField);
+    }
+    if (this.callSetterFor.anotherField0) {
+      objectToBuild.setAnotherField(this.fieldValue.anotherField0);
+    }
+    if (this.callSetterFor.anotherField1) {
+      objectToBuild.setAnotherField(this.fieldValue.anotherField1);
+    }
+    if (this.callSetterFor.field) {
+      objectToBuild.setField(this.fieldValue.field);
+    }
+    if (this.callSetterFor.field0) {
+      objectToBuild.setField(this.fieldValue.field0);
+    }
+    return objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean anotherField;
+
+    boolean anotherField0;
+
+    boolean anotherField1;
+
+    boolean field;
+
+    boolean field0;
+  }
+
+  private class FieldValue {
+    boolean anotherField;
+
+    int anotherField0;
+
+    String anotherField1;
+
+    int field;
+
+    String field0;
+  }
+}

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojo.java
@@ -34,8 +34,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.util.function.Predicate.not;
-
 /**
  * <p>
  * A maven plugin for generating fluent builders for existing classes with the help of reflection. This can be useful in
@@ -183,7 +181,7 @@ public class GenerateBuildersMojo extends AbstractMojo {
     }
 
     private boolean buildContextHasDelta(final BuilderMetadata builderMetadata) {
-        return determineSourceOrClassLocation(builderMetadata).map(mavenBuild::hasDelta).orElse(true);
+        return determineSourceOrClassLocation(builderMetadata).map(mavenBuild::hasDelta).orElse(false);
     }
 
     private Optional<File> determineSourceOrClassLocation(final BuilderMetadata builderMetadata) {
@@ -191,7 +189,7 @@ public class GenerateBuildersMojo extends AbstractMojo {
     }
 
     private Optional<Path> determineSourceOrClassLocation(final BuiltType type) {
-        return determineSourceLocation(type).or(type::getLocation).filter(not(mavenBuild::containsClassFile));
+        return determineSourceLocation(type).or(type::getLocation);
     }
 
     private Optional<Path> determineSourceLocation(final BuiltType type) {

--- a/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/OrphanDeleter.java
+++ b/reflective-fluent-builders-maven-plugin/src/main/java/io/github/tobi/laa/reflective/fluent/builders/mojo/OrphanDeleter.java
@@ -79,11 +79,11 @@ class OrphanDeleter extends AbstractLogEnabled {
             }
             return super.postVisitDirectory(dir, exc);
         }
-    }
 
-    private boolean isEmptyDir(final Path dir) throws IOException {
-        try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(dir)) {
-            return !directoryStream.iterator().hasNext();
+        private boolean isEmptyDir(final Path dir) throws IOException {
+            try (final DirectoryStream<Path> directoryStream = Files.newDirectoryStream(dir)) {
+                return !directoryStream.iterator().hasNext();
+            }
         }
     }
 }

--- a/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/MavenBuildTest.java
+++ b/reflective-fluent-builders-maven-plugin/src/test/java/io/github/tobi/laa/reflective/fluent/builders/mojo/MavenBuildTest.java
@@ -12,6 +12,7 @@ import org.codehaus.plexus.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -22,6 +23,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -47,6 +52,9 @@ class MavenBuildTest {
 
     @Mock
     private Logger logger;
+
+    @TempDir
+    private Path tempDir;
 
     @BeforeEach
     void injectLogger() {
@@ -74,13 +82,71 @@ class MavenBuildTest {
     }
 
     @Test
-    void testHasDelta() {
+    void testHasDeltaProjectFile() {
         // Arrange
-        final File file = new File("");
+        final Path basedir = Paths.get("base");
+        final Path file = basedir.resolve("sth");
+        doReturn(basedir.toFile()).when(mavenProject).getBasedir();
         // Act
-        mavenBuild.hasDelta(file);
+        mavenBuild.hasDelta(file.toFile());
         // Assert
-        verify(buildContext).hasDelta(file);
+        verify(buildContext).hasDelta(file.toFile());
+    }
+
+    @Test
+    void testHasDeltaExternalFileNotExists() {
+        // Arrange
+        final Path basedir = Paths.get("base");
+        final Path file = Paths.get("somewhere", "over", "the", "rainbow");
+        doReturn(basedir.toFile()).when(mavenProject).getBasedir();
+        // Act
+        final boolean hasDelta = mavenBuild.hasDelta(file.toFile());
+        // Assert
+        assertThat(hasDelta).isFalse();
+    }
+
+    @Test
+    @SneakyThrows
+    void testHasDeltaExternalFileUnknown() {
+        // Arrange
+        final Path basedir = Paths.get("base");
+        final Path file = tempDir.resolve("dummy");
+        Files.createFile(file);
+        doReturn(basedir.toFile()).when(mavenProject).getBasedir();
+        // Act
+        final boolean hasDelta = mavenBuild.hasDelta(file.toFile());
+        // Assert
+        assertThat(hasDelta).isTrue();
+    }
+
+    @Test
+    @SneakyThrows
+    void testHasDeltaExternalFileNewer() {
+        // Arrange
+        final Path basedir = Paths.get("base");
+        final Path file = tempDir.resolve("dummy");
+        Files.createFile(file);
+        doReturn(basedir.toFile()).when(mavenProject).getBasedir();
+        doReturn(Instant.MIN).when(buildContext).getValue(anyString());
+        // Act
+        final boolean hasDelta = mavenBuild.hasDelta(file.toFile());
+        // Assert
+        assertThat(hasDelta).isTrue();
+    }
+
+    @Test
+    @SneakyThrows
+    void testHasDeltaExternalFileNotNewer() {
+        // Arrange
+        final Path basedir = Paths.get("base");
+        final Path file = tempDir.resolve("dummy");
+        Files.createFile(file);
+        doReturn(basedir.toFile()).when(mavenProject).getBasedir();
+        doReturn(Instant.MAX).when(buildContext).getValue(anyString());
+        // Act
+        final boolean hasDelta = mavenBuild.hasDelta(file.toFile());
+        // Assert
+        assertThat(hasDelta).isFalse();
     }
 
     @Test
@@ -93,13 +159,41 @@ class MavenBuildTest {
     }
 
     @Test
-    void testRefresh() {
+    void testRefreshProjectFile() {
         // Arrange
-        final File file = new File("");
+        final Path basedir = Paths.get("base");
+        final Path file = basedir.resolve("sth");
+        doReturn(basedir.toFile()).when(mavenProject).getBasedir();
         // Act
-        mavenBuild.refresh(file);
+        mavenBuild.refresh(file.toFile());
         // Assert
-        verify(buildContext).refresh(file);
+        verify(buildContext).refresh(file.toFile());
+    }
+
+    @Test
+    void testRefreshExternalFileNotExists() {
+        // Arrange
+        final Path basedir = Paths.get("base");
+        final Path file = Paths.get("somewhere", "over", "the", "rainbow");
+        doReturn(basedir.toFile()).when(mavenProject).getBasedir();
+        // Act
+        mavenBuild.refresh(file.toFile());
+        // Assert
+        verifyNoInteractions(buildContext);
+    }
+
+    @Test
+    @SneakyThrows
+    void testRefreshExternalFileExists() {
+        // Arrange
+        final Path basedir = Paths.get("base");
+        final Path file = tempDir.resolve("dummy");
+        Files.createFile(file);
+        doReturn(basedir.toFile()).when(mavenProject).getBasedir();
+        // Act
+        mavenBuild.refresh(file.toFile());
+        // Assert
+        verify(buildContext).setValue(contains(file.toString()), any(Instant.class));
     }
 
     @ParameterizedTest

--- a/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/NameCollisions.java
+++ b/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/complex/NameCollisions.java
@@ -1,0 +1,24 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.complex;
+
+public class NameCollisions {
+
+    public void setField(String field) {
+        // no content
+    }
+
+    public void setField(int field) {
+        // no content
+    }
+
+    public void setAnotherField(String anotherField) {
+        // no content
+    }
+
+    public void setAnotherField(int anotherField) {
+        // no content
+    }
+
+    public void setAnotherField(boolean anotherField) {
+        // no content
+    }
+}


### PR DESCRIPTION
Deltas for non-source/non-project files broken. Leads to build loops as described by #130.

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests,
  integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [x] Build pipeline passes.