### PR TITLE
#233 Add Exception handling for generated builders

### DIFF
--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/BuildMethodCodeGeneratorImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/generator/impl/BuildMethodCodeGeneratorImpl.java
@@ -47,6 +47,12 @@ class BuildMethodCodeGeneratorImpl implements BuildMethodCodeGenerator {
         final MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("build")
                 .addModifiers(Modifier.PUBLIC)
                 .returns(clazz.loadClass());
+        builderMetadata
+                .getExceptionTypes()
+                .stream()
+                .filter(this::isCheckedException)
+                .sorted(Comparator.comparing(Class::getName))
+                .forEach(methodBuilder::addException);
         methodBuilder.addStatement("final $T $L = this.$L.get()", clazz.loadClass(), OBJECT_TO_BUILD_FIELD_NAME, OBJECT_SUPPLIER_FIELD_NAME);
         for (final WriteAccessor writeAccessor : builderMetadata.getBuiltType().getWriteAccessors()) {
             stepCodeGenerators.stream()
@@ -55,5 +61,9 @@ class BuildMethodCodeGeneratorImpl implements BuildMethodCodeGenerator {
         }
         methodBuilder.addStatement("return $L", OBJECT_TO_BUILD_FIELD_NAME);
         return methodBuilder.build();
+    }
+
+    private boolean isCheckedException(final Class<? extends Throwable> exceptionType) {
+        return !RuntimeException.class.isAssignableFrom(exceptionType) && !Error.class.isAssignableFrom(exceptionType);
     }
 }

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/AbstractMethodAccessor.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/AbstractMethodAccessor.java
@@ -1,10 +1,12 @@
 package io.github.tobi.laa.reflective.fluent.builders.model;
 
 import lombok.Data;
+import lombok.Singular;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * <p>
@@ -15,7 +17,7 @@ import java.util.Objects;
 @SuperBuilder(toBuilder = true)
 @Data
 @ToString(callSuper = true)
-abstract class AbstractMethodAccessor extends AbstractWriteAccessor {
+abstract class AbstractMethodAccessor extends AbstractWriteAccessor implements MethodAccessor {
 
     /**
      * <p>
@@ -24,6 +26,18 @@ abstract class AbstractMethodAccessor extends AbstractWriteAccessor {
      */
     @lombok.NonNull
     private final String methodName;
+
+    /**
+     * <p>
+     * The types of exceptions that can be thrown by the method.
+     * </p>
+     * <p>
+     * If no exceptions can be thrown, this set is empty.
+     * </p>
+     */
+    @lombok.NonNull
+    @Singular
+    private final Set<Class<? extends Throwable>> exceptionTypes;
 
     @Override
     public boolean equals(final Object anObject) {

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/BuilderMetadata.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/BuilderMetadata.java
@@ -7,6 +7,7 @@ import lombok.Singular;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedSet;
 
 /**
@@ -26,6 +27,16 @@ public class BuilderMetadata {
 
     @lombok.NonNull
     private final BuiltType builtType;
+
+    /**
+     * <p>
+     * The types of exceptions that can be thrown by the builder's {@code build} method. If no exceptions can be thrown,
+     * this set is empty. The exceptions contained are the condensed exceptions of all {@link WriteAccessor}s.
+     * </p>
+     */
+    @lombok.NonNull
+    @Singular
+    private final Set<Class<? extends Throwable>> exceptionTypes;
 
     @lombok.Builder
     @Data

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/MethodAccessor.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/model/MethodAccessor.java
@@ -1,0 +1,28 @@
+package io.github.tobi.laa.reflective.fluent.builders.model;
+
+import java.util.Set;
+
+/**
+ * <p>
+ * A {@link WriteAccessor} that represents a method, i.e. a setter, adder or getter of a collection or map.
+ * </p>
+ */
+public interface MethodAccessor extends WriteAccessor {
+    
+    /**
+     * <p>
+     * The name of the method, for instance {@code setAge}.
+     * </p>
+     */
+    String getMethodName();
+
+    /**
+     * <p>
+     * The types of exceptions that can be thrown by the method.
+     * </p>
+     * <p>
+     * If no exceptions can be thrown, this set is empty.
+     * </p>
+     */
+    Set<Class<? extends Throwable>> getExceptionTypes();
+}

--- a/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/WriteAccessorServiceImpl.java
+++ b/reflective-fluent-builders-generator/src/main/java/io/github/tobi/laa/reflective/fluent/builders/service/impl/WriteAccessorServiceImpl.java
@@ -20,7 +20,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.lang.reflect.Modifier.isStatic;
+import static java.util.Arrays.stream;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.uncapitalize;
 
 /**
@@ -204,7 +206,15 @@ class WriteAccessorServiceImpl implements WriteAccessorService {
                 .paramType(paramType) //
                 .visibility(visibilityService.toVisibility(method.getModifiers())) //
                 .declaringClass(method.getDeclaringClass()) //
+                .exceptionTypes(gatherExceptionTypes(method)) //
                 .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<Class<? extends Throwable>> gatherExceptionTypes(final Method method) {
+        return stream(method.getExceptionTypes())
+                .map(type -> (Class<? extends Throwable>) type)
+                .collect(toSet());
     }
 
     private String pluralize(final String name) {
@@ -219,6 +229,7 @@ class WriteAccessorServiceImpl implements WriteAccessorService {
                 .propertyName(dropSetterPrefix(method.getName())) //
                 .visibility(visibilityService.toVisibility(method.getModifiers())) //
                 .declaringClass(method.getDeclaringClass()) //
+                .exceptionTypes(gatherExceptionTypes(method)) //
                 .build();
     }
 
@@ -245,6 +256,7 @@ class WriteAccessorServiceImpl implements WriteAccessorService {
                 .propertyName(dropGetterPrefix(method.getName())) //
                 .visibility(visibilityService.toVisibility(method.getModifiers())) //
                 .declaringClass(method.getDeclaringClass()) //
+                .exceptionTypes(gatherExceptionTypes(method)) //
                 .build();
     }
 

--- a/reflective-fluent-builders-maven-plugin/src/it/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/java/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT.java
@@ -14,6 +14,7 @@ import io.github.tobi.laa.reflective.fluent.builders.test.models.simple.SimpleCl
 import io.github.tobi.laa.reflective.fluent.builders.test.models.simple.SimpleClassNoSetPrefix;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.simple.hierarchy.Child;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.simple.hierarchy.Parent;
+import io.github.tobi.laa.reflective.fluent.builders.test.models.throwing.ThrowsThrowable;
 import io.github.tobi.laa.reflective.fluent.builders.test.models.visibility.Visibility;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -104,6 +105,16 @@ class GenerateBuildersMojoIT {
                     .project() //
                     .hasTarget() //
                     .has(expectedBuilders(Jaxb.class.getPackage(), false));
+            assertThat(result).out().warn().isEmpty();
+        }
+
+        @MavenTest
+        void packageThrowing(final MavenExecutionResult result) {
+            assertThat(result) //
+                    .isSuccessful() //
+                    .project() //
+                    .hasTarget() //
+                    .has(expectedBuilders(ThrowsThrowable.class.getPackage(), false));
             assertThat(result).out().warn().isEmpty();
         }
     }

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsErrorBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsErrorBuilder.java
@@ -1,0 +1,59 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class ThrowsErrorBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
+  @SuppressWarnings("unused")
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
+  private final Supplier<ThrowsError> objectSupplier;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  protected ThrowsErrorBuilder(final Supplier<ThrowsError> objectSupplier) {
+    this.objectSupplier = Objects.requireNonNull(objectSupplier);
+  }
+
+  public static ThrowsErrorBuilder newInstance() {
+    return new ThrowsErrorBuilder(ThrowsError::new);
+  }
+
+  public static ThrowsErrorBuilder withSupplier(final Supplier<ThrowsError> supplier) {
+    return new ThrowsErrorBuilder(supplier);
+  }
+
+  public ThrowsErrorBuilder aString(final String aString) {
+    this.fieldValue.aString = aString;
+    this.callSetterFor.aString = true;
+    return this;
+  }
+
+  public ThrowsError build() {
+    final ThrowsError objectToBuild = this.objectSupplier.get();
+    if (this.callSetterFor.aString) {
+      objectToBuild.setAString(this.fieldValue.aString);
+    }
+    return objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean aString;
+  }
+
+  private class FieldValue {
+    String aString;
+  }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsExceptionBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsExceptionBuilder.java
@@ -1,0 +1,110 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+import java.lang.Exception;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class ThrowsExceptionBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
+  @SuppressWarnings("unused")
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
+  private final Supplier<ThrowsException> objectSupplier;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  protected ThrowsExceptionBuilder(final Supplier<ThrowsException> objectSupplier) {
+    this.objectSupplier = Objects.requireNonNull(objectSupplier);
+  }
+
+  public static ThrowsExceptionBuilder newInstance() {
+    return new ThrowsExceptionBuilder(ThrowsException::new);
+  }
+
+  public static ThrowsExceptionBuilder withSupplier(final Supplier<ThrowsException> supplier) {
+    return new ThrowsExceptionBuilder(supplier);
+  }
+
+  public CollectionList list() {
+    return new CollectionList();
+  }
+
+  public ThrowsExceptionBuilder anInt(final int anInt) {
+    this.fieldValue.anInt = anInt;
+    this.callSetterFor.anInt = true;
+    return this;
+  }
+
+  public ThrowsExceptionBuilder anItem(final String anItem) {
+    if (this.fieldValue.anItems == null) {
+      this.fieldValue.anItems = new ArrayList<>();
+    }
+    this.fieldValue.anItems.add(anItem);
+    this.callSetterFor.anItems = true;
+    return this;
+  }
+
+  public ThrowsExceptionBuilder list(final List<String> list) {
+    this.fieldValue.list = list;
+    this.callSetterFor.list = true;
+    return this;
+  }
+
+  public ThrowsException build() throws Exception {
+    final ThrowsException objectToBuild = this.objectSupplier.get();
+    if (this.callSetterFor.anInt) {
+      objectToBuild.setAnInt(this.fieldValue.anInt);
+    }
+    if (this.callSetterFor.anItems && this.fieldValue.anItems != null) {
+      this.fieldValue.anItems.forEach(objectToBuild::addAnItem);
+    }
+    if (this.callSetterFor.list && this.fieldValue.list != null) {
+      this.fieldValue.list.forEach(objectToBuild.getList()::add);
+    }
+    return objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean anInt;
+
+    boolean anItems;
+
+    boolean list;
+  }
+
+  private class FieldValue {
+    int anInt;
+
+    List<String> anItems;
+
+    List<String> list;
+  }
+
+  public class CollectionList {
+    public CollectionList add(final String item) {
+      if (ThrowsExceptionBuilder.this.fieldValue.list == null) {
+        ThrowsExceptionBuilder.this.fieldValue.list = new ArrayList<>();
+      }
+      ThrowsExceptionBuilder.this.fieldValue.list.add(item);
+      ThrowsExceptionBuilder.this.callSetterFor.list = true;
+      return this;
+    }
+
+    public ThrowsExceptionBuilder and() {
+      return ThrowsExceptionBuilder.this;
+    }
+  }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsMultipleCheckedExceptionsBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsMultipleCheckedExceptionsBuilder.java
@@ -1,0 +1,91 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+import java.io.IOException;
+import java.lang.IllegalAccessException;
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.text.ParseException;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class ThrowsMultipleCheckedExceptionsBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
+  @SuppressWarnings("unused")
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
+  private final Supplier<ThrowsMultipleCheckedExceptions> objectSupplier;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  protected ThrowsMultipleCheckedExceptionsBuilder(
+      final Supplier<ThrowsMultipleCheckedExceptions> objectSupplier) {
+    this.objectSupplier = Objects.requireNonNull(objectSupplier);
+  }
+
+  public static ThrowsMultipleCheckedExceptionsBuilder newInstance() {
+    return new ThrowsMultipleCheckedExceptionsBuilder(ThrowsMultipleCheckedExceptions::new);
+  }
+
+  public static ThrowsMultipleCheckedExceptionsBuilder withSupplier(
+      final Supplier<ThrowsMultipleCheckedExceptions> supplier) {
+    return new ThrowsMultipleCheckedExceptionsBuilder(supplier);
+  }
+
+  public ThrowsMultipleCheckedExceptionsBuilder aLong(final long aLong) {
+    this.fieldValue.aLong = aLong;
+    this.callSetterFor.aLong = true;
+    return this;
+  }
+
+  public ThrowsMultipleCheckedExceptionsBuilder aString(final String aString) {
+    this.fieldValue.aString = aString;
+    this.callSetterFor.aString = true;
+    return this;
+  }
+
+  public ThrowsMultipleCheckedExceptionsBuilder anInt(final int anInt) {
+    this.fieldValue.anInt = anInt;
+    this.callSetterFor.anInt = true;
+    return this;
+  }
+
+  public ThrowsMultipleCheckedExceptions build() throws IOException, IllegalAccessException,
+      ParseException {
+    final ThrowsMultipleCheckedExceptions objectToBuild = this.objectSupplier.get();
+    if (this.callSetterFor.aLong) {
+      objectToBuild.setALong(this.fieldValue.aLong);
+    }
+    if (this.callSetterFor.aString) {
+      objectToBuild.setAString(this.fieldValue.aString);
+    }
+    if (this.callSetterFor.anInt) {
+      objectToBuild.setAnInt(this.fieldValue.anInt);
+    }
+    return objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean aLong;
+
+    boolean aString;
+
+    boolean anInt;
+  }
+
+  private class FieldValue {
+    long aLong;
+
+    String aString;
+
+    int anInt;
+  }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsRuntimeExceptionBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsRuntimeExceptionBuilder.java
@@ -1,0 +1,91 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class ThrowsRuntimeExceptionBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
+  @SuppressWarnings("unused")
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
+  private final Supplier<ThrowsRuntimeException> objectSupplier;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  protected ThrowsRuntimeExceptionBuilder(final Supplier<ThrowsRuntimeException> objectSupplier) {
+    this.objectSupplier = Objects.requireNonNull(objectSupplier);
+  }
+
+  public static ThrowsRuntimeExceptionBuilder newInstance() {
+    return new ThrowsRuntimeExceptionBuilder(ThrowsRuntimeException::new);
+  }
+
+  public static ThrowsRuntimeExceptionBuilder withSupplier(
+      final Supplier<ThrowsRuntimeException> supplier) {
+    return new ThrowsRuntimeExceptionBuilder(supplier);
+  }
+
+  public ThrowsRuntimeExceptionBuilder aString(final String aString) {
+    this.fieldValue.aString = aString;
+    this.callSetterFor.aString = true;
+    return this;
+  }
+
+  public ThrowsRuntimeExceptionBuilder anInt(final int anInt) {
+    this.fieldValue.anInt = anInt;
+    this.callSetterFor.anInt = true;
+    return this;
+  }
+
+  public ThrowsRuntimeExceptionBuilder anItem(final String anItem) {
+    if (this.fieldValue.anItems == null) {
+      this.fieldValue.anItems = new ArrayList<>();
+    }
+    this.fieldValue.anItems.add(anItem);
+    this.callSetterFor.anItems = true;
+    return this;
+  }
+
+  public ThrowsRuntimeException build() {
+    final ThrowsRuntimeException objectToBuild = this.objectSupplier.get();
+    if (this.callSetterFor.aString) {
+      objectToBuild.setAString(this.fieldValue.aString);
+    }
+    if (this.callSetterFor.anInt) {
+      objectToBuild.setAnInt(this.fieldValue.anInt);
+    }
+    if (this.callSetterFor.anItems && this.fieldValue.anItems != null) {
+      this.fieldValue.anItems.forEach(objectToBuild::addAnItem);
+    }
+    return objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean aString;
+
+    boolean anInt;
+
+    boolean anItems;
+  }
+
+  private class FieldValue {
+    String aString;
+
+    int anInt;
+
+    List<String> anItems;
+  }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsThrowableBuilder.java
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/expected-builders/default-config/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsThrowableBuilder.java
@@ -1,0 +1,136 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+import java.lang.String;
+import java.lang.SuppressWarnings;
+import java.lang.Throwable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "io.github.tobi.laa.reflective.fluent.builders.generator.api.JavaFileGenerator",
+    date = "3333-03-13T00:00Z[UTC]"
+)
+public class ThrowsThrowableBuilder {
+  /**
+   * This field is solely used to be able to detect generated builders via reflection at a later stage.
+   */
+  @SuppressWarnings("unused")
+  private boolean ______generatedByReflectiveFluentBuildersGenerator;
+
+  private final Supplier<ThrowsThrowable> objectSupplier;
+
+  private final CallSetterFor callSetterFor = new CallSetterFor();
+
+  private final FieldValue fieldValue = new FieldValue();
+
+  protected ThrowsThrowableBuilder(final Supplier<ThrowsThrowable> objectSupplier) {
+    this.objectSupplier = Objects.requireNonNull(objectSupplier);
+  }
+
+  public static ThrowsThrowableBuilder newInstance() {
+    return new ThrowsThrowableBuilder(ThrowsThrowable::new);
+  }
+
+  public static ThrowsThrowableBuilder withSupplier(final Supplier<ThrowsThrowable> supplier) {
+    return new ThrowsThrowableBuilder(supplier);
+  }
+
+  public CollectionList list() {
+    return new CollectionList();
+  }
+
+  public ThrowsThrowableBuilder aLong(final long aLong) {
+    this.fieldValue.aLong = aLong;
+    this.callSetterFor.aLong = true;
+    return this;
+  }
+
+  public ThrowsThrowableBuilder aString(final String aString) {
+    this.fieldValue.aString = aString;
+    this.callSetterFor.aString = true;
+    return this;
+  }
+
+  public ThrowsThrowableBuilder anInt(final int anInt) {
+    this.fieldValue.anInt = anInt;
+    this.callSetterFor.anInt = true;
+    return this;
+  }
+
+  public ThrowsThrowableBuilder anItem(final String anItem) {
+    if (this.fieldValue.anItems == null) {
+      this.fieldValue.anItems = new ArrayList<>();
+    }
+    this.fieldValue.anItems.add(anItem);
+    this.callSetterFor.anItems = true;
+    return this;
+  }
+
+  public ThrowsThrowableBuilder list(final List<String> list) {
+    this.fieldValue.list = list;
+    this.callSetterFor.list = true;
+    return this;
+  }
+
+  public ThrowsThrowable build() throws Throwable {
+    final ThrowsThrowable objectToBuild = this.objectSupplier.get();
+    if (this.callSetterFor.aLong) {
+      objectToBuild.setALong(this.fieldValue.aLong);
+    }
+    if (this.callSetterFor.aString) {
+      objectToBuild.setAString(this.fieldValue.aString);
+    }
+    if (this.callSetterFor.anInt) {
+      objectToBuild.setAnInt(this.fieldValue.anInt);
+    }
+    if (this.callSetterFor.anItems && this.fieldValue.anItems != null) {
+      this.fieldValue.anItems.forEach(objectToBuild::addAnItem);
+    }
+    if (this.callSetterFor.list && this.fieldValue.list != null) {
+      this.fieldValue.list.forEach(objectToBuild.getList()::add);
+    }
+    return objectToBuild;
+  }
+
+  private class CallSetterFor {
+    boolean aLong;
+
+    boolean aString;
+
+    boolean anInt;
+
+    boolean anItems;
+
+    boolean list;
+  }
+
+  private class FieldValue {
+    long aLong;
+
+    String aString;
+
+    int anInt;
+
+    List<String> anItems;
+
+    List<String> list;
+  }
+
+  public class CollectionList {
+    public CollectionList add(final String item) {
+      if (ThrowsThrowableBuilder.this.fieldValue.list == null) {
+        ThrowsThrowableBuilder.this.fieldValue.list = new ArrayList<>();
+      }
+      ThrowsThrowableBuilder.this.fieldValue.list.add(item);
+      ThrowsThrowableBuilder.this.callSetterFor.list = true;
+      return this;
+    }
+
+    public ThrowsThrowableBuilder and() {
+      return ThrowsThrowableBuilder.this;
+    }
+  }
+}

--- a/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/WithDefaultConfig/packageThrowing/pom.xml
+++ b/reflective-fluent-builders-maven-plugin/src/it/resources/io/github/tobi/laa/reflective/fluent/builders/mojo/GenerateBuildersMojoIT/WithDefaultConfig/packageThrowing/pom.xml
@@ -1,0 +1,45 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.tobi-laa</groupId>
+        <artifactId>reflective-fluent-builders</artifactId>
+        <version>@project.version@</version>
+    </parent>
+    <artifactId>reflective-fluent-builders-it</artifactId>
+    <description>Integration test for the maven plugin</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.tobi-laa</groupId>
+            <artifactId>reflective-fluent-builders-test</artifactId>
+            <version>@project.version@</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.tobi-laa</groupId>
+                <artifactId>reflective-fluent-builders-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate-builders</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>
+                            <packageName>
+                                io.github.tobi.laa.reflective.fluent.builders.test.models.throwing
+                            </packageName>
+                        </include>
+                    </includes>
+                    <target>\${project.build.directory}/generated-sources/builders</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsError.java
+++ b/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsError.java
@@ -1,0 +1,9 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+@SuppressWarnings("all")
+public class ThrowsError {
+
+    public void setAString(final String aString) throws StackOverflowError {
+        // do nothing
+    }
+}

--- a/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsException.java
+++ b/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsException.java
@@ -1,0 +1,20 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+import java.io.IOException;
+import java.util.List;
+
+@SuppressWarnings("all")
+public class ThrowsException {
+
+    public void setAnInt(final int anInt) throws IOException {
+        // do nothing
+    }
+
+    public List<String> getList() throws Exception {
+        throw new Exception();
+    }
+
+    void addAnItem(final String item) throws RuntimeException {
+        // do nothing
+    }
+}

--- a/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsMultipleCheckedExceptions.java
+++ b/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsMultipleCheckedExceptions.java
@@ -1,0 +1,20 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+@SuppressWarnings("all")
+public class ThrowsMultipleCheckedExceptions {
+
+    public void setAnInt(final int anInt) throws IOException {
+        // do nothing
+    }
+
+    public void setAString(final String aString) throws IllegalAccessException {
+        // do nothing
+    }
+
+    public void setALong(final long aLong) throws ParseException {
+        // do nothing
+    }
+}

--- a/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsRuntimeException.java
+++ b/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsRuntimeException.java
@@ -1,0 +1,17 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+@SuppressWarnings("all")
+public class ThrowsRuntimeException {
+
+    public void setAnInt(final int anInt) throws IllegalArgumentException {
+        // do nothing
+    }
+
+    public void setAString(final String aString) throws IllegalStateException {
+        // do nothing
+    }
+
+    void addAnItem(final String item) throws RuntimeException {
+        // do nothing
+    }
+}

--- a/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsThrowable.java
+++ b/reflective-fluent-builders-test/src/main/java/io/github/tobi/laa/reflective/fluent/builders/test/models/throwing/ThrowsThrowable.java
@@ -1,0 +1,28 @@
+package io.github.tobi.laa.reflective.fluent.builders.test.models.throwing;
+
+import java.io.IOException;
+import java.util.List;
+
+@SuppressWarnings("all")
+public class ThrowsThrowable {
+
+    public void setAnInt(final int anInt) throws IOException {
+        // do nothing
+    }
+
+    public void setAString(final String aString) throws StackOverflowError {
+        // do nothing
+    }
+
+    public void setALong(final long aLong) throws Throwable {
+        // do nothing
+    }
+
+    public List<String> getList() throws Exception {
+        throw new Exception();
+    }
+
+    void addAnItem(final String item) throws RuntimeException {
+        // do nothing
+    }
+}


### PR DESCRIPTION
Fixes #233

---

- [x] All commit messages contain meaningful descriptions.
- [x] All public methods, classes and interfaces have meaningful Javadoc.
- [x] Tests have been added covering the changes being made. Depending on the change this might entail unit tests,
  integration tests or both.
- [x] Run the following command to regenerate IT samples and verify that the changes introduced are as expected:
   ```
   mvn clean verify -Pgenerate-expected-builders-for-it
   ```
- [x] Build pipeline passes.